### PR TITLE
Add known issue with older Gradle versions

### DIFF
--- a/docs/troubleshooting/common-issues.md
+++ b/docs/troubleshooting/common-issues.md
@@ -29,6 +29,20 @@ Make sure your branch is clean and all files are indeed present:
 
 A good way to verify this, is to (locally) clone the Unity project in a new folder and run the build from there.
 
+### Gradle error.
+
+#### Error
+
+```console
+Error: 3.690 [ERROR] [org.gradle.launcher.daemon.server.DaemonStateCoordinator] Command execution: started DaemonCommandExecution[command = Build{id=69dbd5b3-10f2-488e-8640-977da68733f9, currentDir=/github/workspace/Temp/gradleOut/launcher}, connection = DefaultDaemonConnection: socket connection from /127.0.0.1:33657 to /127.0.0.1:43866] after 0.0 minutes of idle
+```
+
+#### Solution
+
+There are 2 possible solutions:
+
+- Remove emojis from all environment variables (and thus workflow files), or
+- Upgrade your project and workflow to use Unity editor version 2020.2 or later.
 
 ## I cannot activate because
 

--- a/docs/troubleshooting/common-issues.md
+++ b/docs/troubleshooting/common-issues.md
@@ -29,7 +29,7 @@ Make sure your branch is clean and all files are indeed present:
 
 A good way to verify this, is to (locally) clone the Unity project in a new folder and run the build from there.
 
-### Gradle error.
+### Gradle error
 
 #### Error
 


### PR DESCRIPTION
#### Changes

Add 2 possible solutions for this error when running Gradle while having emojis inside any environment variables.

```
Error: 3.690 [ERROR] [org.gradle.launcher.daemon.server.DaemonStateCoordinator] Command execution: started DaemonCommandExecution[command = Build{id=69dbd5b3-10f2-488e-8640-977da68733f9, currentDir=/github/workspace/Temp/gradleOut/launcher}, connection = DefaultDaemonConnection: socket connection from /127.0.0.1:33657 to /127.0.0.1:43866] after 0.0 minutes of idle
```

#### Checklist

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
