### PR TITLE
gitlab docs updates

### DIFF
--- a/docs/gitlab/activation.md
+++ b/docs/gitlab/activation.md
@@ -68,9 +68,9 @@ All you need is [docker](https://www.docker.com/) installed on your machine.
 6. Open https://license.unity3d.com/manual and answer questions
 7. Upload `unity3d.alf` for manual activation
 8. Download `Unity_v2018.x.ulf` (`Unity_v2019.x.ulf` for 2019 versions)
-9. Copy the content of `Unity_v2018.x.ulf` license file to your CI's environment variable `UNITY_LICENSE_CONTENT`.
+9. Copy the content of `Unity_v2018.x.ulf` license file to your CI's environment variable `UNITY_LICENSE`.
    _Note: if you are doing this on Windows, chances are the [line endings will be wrong as explained here](https://gitlab.com/gableroux/unity3d-gitlab-ci-example/issues/5#note_95831816). Luckily for you, [`.gitlab-ci.yml`](https://github.com/game-ci/unity3d-ci-example/blob/master/.gitlab-ci.yml) of the example project solves this by removing `\r` character from the ENV variable so you'll be alright_
-   [`.gitlab-ci.yml`](https://gitlab.com/gableroux/unity3d-gitlab-ci-example/-/blob/master/.gitlab-ci.yml) will then place the `UNITY_LICENSE_CONTENT` to the right place before running tests or creating the builds.
+   [`.gitlab-ci.yml`](https://gitlab.com/gableroux/unity3d-gitlab-ci-example/-/blob/master/.gitlab-ci.yml) will then place the `UNITY_LICENSE` to the right place before running tests or creating the builds.
 
 ## Unity Plus/Pro
 
@@ -104,9 +104,9 @@ All you need is [docker](https://www.docker.com/) installed on your machine.
 
 4. Wait for the command to finish without errors
 5. Obtain the contents of the license file by running `cat /root/.local/share/unity3d/Unity/Unity_lic.ulf`
-6. Copy the content to your CI's environment variable `UNITY_LICENSE_CONTENT`.
+6. Copy the content to your CI's environment variable `UNITY_LICENSE`.
    _Note: if you are doing this on windows, chances are the [line endings will be wrong as explained here](https://gitlab.com/gableroux/unity3d-gitlab-ci-example/issues/5#note_95831816). Luckily for you, [`.gitlab-ci.yml`](https://gitlab.com/gableroux/unity3d-gitlab-ci-example/-/blob/master/.gitlab-ci.yml) solves this by removing `\r` character from the env variable so you'll be alright_
-   [`.gitlab-ci.yml`](https://gitlab.com/gableroux/unity3d-gitlab-ci-example/-/blob/master/.gitlab-ci.yml) will then place the `UNITY_LICENSE_CONTENT` to the right place before running tests or creating the builds.
+   [`.gitlab-ci.yml`](https://gitlab.com/gableroux/unity3d-gitlab-ci-example/-/blob/master/.gitlab-ci.yml) will then place the `UNITY_LICENSE` to the right place before running tests or creating the builds.
 
 ## Unity license per target
 

--- a/docs/gitlab/android.md
+++ b/docs/gitlab/android.md
@@ -1,6 +1,6 @@
 # Android
 
-To make build working with Android, you will need a specific Unity license (because that is not the same docker image). Add the content of your specific Unity license in your CI's environment variable : `UNITY_LICENSE_CONTENT_ANDROID`
+Before `2018.4.8f1` for 2018 versions and before `2019.2.4f1` for 2019 versions, you will need a specific Unity license (because that is not the same docker image). Add the content of your specific Unity license in your CI's environment variable : `UNITY_LICENSE_CONTENT_ANDROID`.\_This is not required anymore now that images share a base image [See related change](https://gitlab.com/gableroux/unity3d/merge_requests/63)\*\*
 
 By default the apk is not signed and the build will use the Unity's default debug key.
 For _security reasons_, **you should not add your keystore to git**.

--- a/docs/gitlab/getting-started.md
+++ b/docs/gitlab/getting-started.md
@@ -18,7 +18,7 @@ Any subsequent steps assume you have read the above.
 
 ## Supported versions
 
-The [unity3d-gitlab-ci-example project](https://gitlab.com/gableroux/unity3d-gitlab-ci-example/) is based on [unity3d](https://gitlab.com/gableroux/unity3d) docker images from [GabLeRoux](https://github.com/GabLeRoux). Any version in the [docker hub `gableroux/unity3d` tags list](https://hub.docker.com/r/gableroux/unity3d/tags) can be used to test and build projects.
+The [unity3d-gitlab-ci-example project](https://gitlab.com/gableroux/unity3d-gitlab-ci-example/) is based on [unity3d](https://github.com/game-ci/docker/) docker images from [game-ci](https://github.com/game-ci). Any version in the [docker hub `unityci/editor` tags list](https://hub.docker.com/r/unityci/editor/tags) can be used to test and build projects.
 
 It's generally considered good practice to use the same Unity version for your CI/CD setup as you do to develop your project.
 


### PR DESCRIPTION
#### Changes

In the gitlab docs:
- Update links to docker images
- Update license variable name to `UNITY_LICENSE`
- Update note at the top of Android page about requiring a specific license variable

#### Checklist

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [ ] Readme (updated or not needed)
- [ ] Tests (added, updated or not needed)
