### PR TITLE
Add github/iOS documentation

### DIFF
--- a/components/layout/main/documentation-sidebar.js
+++ b/components/layout/main/documentation-sidebar.js
@@ -67,6 +67,11 @@ const DocumentationSidebar = () => {
               <a>Returning a license</a>
             </Link>
           </Item>
+          <Item key="/docs/github/ios">
+            <Link href="/docs/[...ios]" as="/docs/github/ios">
+              <a>iOS</a>
+            </Link>
+          </Item>
         </SubMenu>
         <SubMenu key="gitlab" icon={<SiGitlab />} title="GitLab">
           <Item key="/docs/gitlab/getting-started">

--- a/docs/github/ios.md
+++ b/docs/github/ios.md
@@ -104,7 +104,7 @@ platform :ios do
       profile: ENV["sigh_com.company.application_appstore_profile-path"],
       code_signing_identity: "Apple Distribution: #{ENV['APPLE_TEAM_NAME']} (#{ENV['APPLE_TEAM_ID']})"
     )
-	increment_build_number(
+    increment_build_number(
        xcodeproj: "#{ENV['IOS_BUILD_PATH']}/iOS/Unity-iPhone.xcodeproj"
     )
     gym(
@@ -164,27 +164,16 @@ end
 # .github/workflows/main.yml
 
 buildForiOsPlatform:
-  name: Build for ${{ matrix.targetPlatform }} on version ${{ matrix.unityVersion }}
+  name: Build for iOS
   runs-on: ubuntu-latest
-  strategy:
-    fail-fast: false
-    matrix:
-      projectPath:
-        - .
-      unityVersion:
-        - 2020.2.2f1
-      targetPlatform:
-        - iOS
   steps:
     - uses: actions/checkout@v2
     - uses: actions/cache@v2
       with:
         path: Library
         key: Library-${{ matrix.targetPlatform }}-v2
-    - uses: webbertakken/unity-builder@v2.0-alpha-6
+    - uses: game-ci/unity-builder@v2.0-alpha-6
       with:
-        projectPath: ${{ matrix.projectPath }}
-        unityVersion: ${{ matrix.unityVersion }}
         targetPlatform: ${{ matrix.targetPlatform }}
     - uses: actions/upload-artifact@v2
       with:


### PR DESCRIPTION
#### Changes

I recently add CI/CD for one of my iOS projects, and It was a very time-consuming task!
Both because of the lack of a complete iOS CI/CD tutorial with unity and also the [apple recent changes](https://github.com/fastlane/fastlane/issues/18098?notification_referrer_id=MDE4Ok5vdGlmaWNhdGlvblRocmVhZDE1NDQwMjAwMjU6NTE3MjI5Ng%3D%3D#issuecomment-774172059), which make old tutorials broken.

So I create this document,  I hope it's helpful

#### Checklist

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
