### PR TITLE
Add additional build info in table

### DIFF
--- a/components/docs/versions/build-failure-details.tsx
+++ b/components/docs/versions/build-failure-details.tsx
@@ -1,0 +1,59 @@
+import Heading from '@/components/markdown/components/heading';
+import React, { useReducer } from 'react';
+
+interface Props {
+  ciJob;
+  ciBuild;
+  repoVersionInfo;
+  style;
+}
+
+const BuildFailureDetails = ({ ciJob, repoVersionInfo, ciBuild, ...rest }: Props) => {
+  const { editorVersion, baseOs, targetPlatform } = ciBuild.buildInfo;
+  const { major, minor, patch } = repoVersionInfo;
+
+  const reducer = (state, action) => {
+    const { tag, value } = action;
+    return { ...state, [tag]: value };
+  };
+
+  const [tags /* , dispatch */] = useReducer(reducer, {
+    [`${baseOs}-${editorVersion}-${targetPlatform}-${major}`]: '❓',
+    [`${baseOs}-${editorVersion}-${targetPlatform}-${major}.${minor}`]: '❓',
+    [`${baseOs}-${editorVersion}-${targetPlatform}-${major}.${minor}.${patch}`]: '❓',
+    [`${editorVersion}-${targetPlatform}-${major}`]: '❓',
+    [`${editorVersion}-${targetPlatform}-${major}.${minor}`]: '❓',
+    [`${editorVersion}-${targetPlatform}-${major}.${minor}.${patch}`]: '❓',
+  });
+
+  // Todo - fetch docker info from dockerhub for all tags, or do it on the server
+  // useEffect(() => {
+  //   (async () => {
+  //     const repo = 'unityci/editor';
+  //     for (const tag of Object.keys(tags)) {
+  //       const requestUrl = `https://index.docker.io/v1/repositories/${repo}/tags/${tag}`;
+  //       try {
+  //         const response = await fetch(requestUrl);
+  //         dispatch({ tag, value: response.status === 0 });
+  //       } catch (error) {
+  //         dispatch({ tag, value: false });
+  //       }
+  //     }
+  //   })();
+  // }, []);
+
+  return (
+    <article {...rest}>
+      <Heading level={4}>CI Job</Heading>
+      <pre>{JSON.stringify(ciJob, null, 2)}</pre>
+      <br />
+      <Heading level={3}>Associated tags</Heading>
+      <pre>{JSON.stringify(tags, null, 2)}</pre>
+      <br />
+      <Heading level={4}>CI Build</Heading>
+      <pre>{JSON.stringify(ciBuild, null, 2)}</pre>
+    </article>
+  );
+};
+
+export default BuildFailureDetails;

--- a/components/docs/versions/date-time.tsx
+++ b/components/docs/versions/date-time.tsx
@@ -13,8 +13,10 @@ const options = {
 };
 
 const DateTime = ({ utcSeconds }: Props) => {
-  const date = new Date(0).setUTCSeconds(utcSeconds);
-  // @ts-ignore
+  const date = new Date(0); // Use epoch
+
+  date.setUTCSeconds(utcSeconds);
+
   return <span>{`${date.toLocaleString('en-GB', options)}`}</span>;
 };
 

--- a/components/docs/versions/unity-version.tsx
+++ b/components/docs/versions/unity-version.tsx
@@ -16,7 +16,7 @@ const UnityVersion = ({ data, ...rest }: Props) => {
     status,
     // imageType,
     // editorVersionInfo,
-    // repoVersionInfo,
+    repoVersionInfo,
     // meta,
     // addedDate,
     modifiedDate,
@@ -45,7 +45,7 @@ const UnityVersion = ({ data, ...rest }: Props) => {
       key={id}
     >
       <Heading level={4}>Status: {status}</Heading>
-      <Builds ciJob={id} />
+      <Builds ciJobId={id} repoVersionInfo={repoVersionInfo} />
       {/* <Heading level={4}>Publication</Heading> */}
       {/* <pre>{JSON.stringify(repoVersionInfo, null, 2)}</pre> */}
       {/* <Heading level={4}>Editor</Heading> */}


### PR DESCRIPTION
#### Changes

- This makes the table that contains the builds for each target platform collapsible.
- More detailed information about the build / docker image publication appears (renders on-open)
- Fix last updated timestamp for all jobs

![image](https://user-images.githubusercontent.com/20756439/109367258-e60cf080-7895-11eb-9504-de20bd39196b.png)


#### Checklist

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [ ] Readme (updated or not needed)
- [ ] Tests (added, updated or not needed)
