### PR TITLE
Retry builds

### DIFF
--- a/components/auth/safe-auth-check.tsx
+++ b/components/auth/safe-auth-check.tsx
@@ -1,6 +1,6 @@
 import firebase from 'firebase';
 import React from 'react';
-import { AuthCheckProps, ClaimsCheckProps, useIdTokenResult, useUser } from 'reactfire';
+import { AuthCheckProps, ClaimsCheckProps, useAuth, useIdTokenResult, useUser } from 'reactfire';
 
 // Apply fix while this is not merged https://github.com/FirebaseExtended/reactfire/pull/336
 export function SafeClaimsCheck({ user, fallback, children, requiredClaims }: ClaimsCheckProps) {
@@ -42,4 +42,18 @@ export function SafeAuthCheck({
   }
 
   return <>{fallback}</>;
+}
+
+export function SimpleAuthCheck({
+  fallback,
+  children,
+  requiredClaims,
+}: Omit<AuthCheckProps, 'auth'>) {
+  const auth = useAuth();
+
+  return (
+    <SafeAuthCheck auth={auth} fallback={fallback} requiredClaims={requiredClaims}>
+      {children}
+    </SafeAuthCheck>
+  );
 }

--- a/components/auth/safe-auth-check.tsx
+++ b/components/auth/safe-auth-check.tsx
@@ -1,0 +1,45 @@
+import firebase from 'firebase';
+import React from 'react';
+import { AuthCheckProps, ClaimsCheckProps, useIdTokenResult, useUser } from 'reactfire';
+
+// Apply fix while this is not merged https://github.com/FirebaseExtended/reactfire/pull/336
+export function SafeClaimsCheck({ user, fallback, children, requiredClaims }: ClaimsCheckProps) {
+  const { data } = useIdTokenResult(user, false, { initialData: { claims: {} } });
+  const { claims } = data;
+  const missingClaims: { [key: string]: { expected: string; actual: string } } = {};
+
+  if (requiredClaims) {
+    for (const claim of Object.keys(requiredClaims)) {
+      if (requiredClaims[claim] !== claims[claim]) {
+        missingClaims[claim] = {
+          expected: requiredClaims[claim],
+          actual: claims[claim],
+        };
+      }
+    }
+  }
+
+  return Object.keys(missingClaims).length === 0 ? <>{children}</> : <>{fallback}</>;
+}
+
+// Apply fix while this is not merged https://github.com/FirebaseExtended/reactfire/pull/336
+export function SafeAuthCheck({
+  auth,
+  fallback,
+  children,
+  requiredClaims,
+}: AuthCheckProps): JSX.Element {
+  const { data: user } = useUser<firebase.User>(auth);
+
+  if (user) {
+    return requiredClaims ? (
+      <SafeClaimsCheck user={user} fallback={fallback} requiredClaims={requiredClaims}>
+        {children}
+      </SafeClaimsCheck>
+    ) : (
+      <>{children}</>
+    );
+  }
+
+  return <>{fallback}</>;
+}

--- a/components/docs/versions/builds.tsx
+++ b/components/docs/versions/builds.tsx
@@ -1,5 +1,5 @@
 import BuildFailureDetails from '@/components/docs/versions/build-failure-details';
-import DockerImageLink from '@/components/docs/versions/docker-image-link';
+import DockerImageLinkOrRetryButton from '@/components/docs/versions/docker-image-link-or-retry-button';
 import { ColumnsType } from 'antd/es/table';
 import React from 'react';
 import { useFirestore, useFirestoreCollectionData } from 'reactfire';
@@ -43,11 +43,8 @@ const Builds = ({ ciJobId, repoVersionInfo, ...props }: Props) => {
     },
     {
       width: 45,
-      render: (value, record) => {
-        const { buildInfo, dockerInfo } = record;
-        return dockerInfo && <DockerImageLink dockerInfo={dockerInfo} buildInfo={buildInfo} />;
-      },
-      key: 'dockerInfo-link-button',
+      render: (value, record) => <DockerImageLinkOrRetryButton record={record} />,
+      key: 'docker-image-link-or-retry-button',
     },
     {
       title: 'Build identifier',

--- a/components/docs/versions/docker-image-link-or-retry-button.tsx
+++ b/components/docs/versions/docker-image-link-or-retry-button.tsx
@@ -1,0 +1,41 @@
+import { SimpleAuthCheck } from '@/components/auth/safe-auth-check';
+import DockerImageLink from '@/components/docs/versions/docker-image-link';
+import { Tooltip } from 'antd';
+import React from 'react';
+import { HiOutlineRefresh } from 'react-icons/all';
+
+interface Props {
+  record: {
+    buildInfo: {
+      baseOs: string;
+      editorVersion: string;
+      targetPlatform: string;
+      repoVersion: string;
+    };
+    dockerInfo: {
+      imageRepo: string;
+      imageName: string;
+    };
+  };
+}
+
+const DockerImageLinkOrRetryButton = ({ record }: Props) => {
+  const { buildInfo, dockerInfo } = record;
+  const { baseOs, editorVersion, targetPlatform, repoVersion } = buildInfo;
+  const { imageRepo, imageName } = dockerInfo || {};
+  const imageTag = `${baseOs}-${editorVersion}-${targetPlatform}-${repoVersion}`;
+
+  if (dockerInfo) {
+    return <DockerImageLink imageRepo={imageRepo} imageName={imageName} imageTag={imageTag} />;
+  }
+
+  return (
+    <SimpleAuthCheck fallback={<span />} requiredClaims={{ admin: true }}>
+      <Tooltip title={`Delete tag "${imageTag}" then click this retry button.`}>
+        <HiOutlineRefresh color="orange" />
+      </Tooltip>
+    </SimpleAuthCheck>
+  );
+};
+
+export default DockerImageLinkOrRetryButton;

--- a/components/docs/versions/docker-image-link.tsx
+++ b/components/docs/versions/docker-image-link.tsx
@@ -2,23 +2,12 @@ import React from 'react';
 import { SiDocker } from 'react-icons/all';
 
 interface Props {
-  buildInfo: {
-    baseOs: string;
-    editorVersion: string;
-    targetPlatform: string;
-    repoVersion: string;
-  };
-  dockerInfo: {
-    imageRepo: string;
-    imageName: string;
-  };
+  imageRepo: string;
+  imageName: string;
+  imageTag: string;
 }
 
-const DockerImageLink = ({ buildInfo, dockerInfo }: Props) => {
-  const { baseOs, editorVersion, targetPlatform, repoVersion } = buildInfo;
-  const { imageRepo, imageName } = dockerInfo || {};
-
-  const filterTag = `${baseOs}-${editorVersion}-${targetPlatform}-${repoVersion}`;
+const DockerImageLink = ({ imageRepo, imageName, imageTag }: Props) => {
   return (
     <a
       aria-label="Image url"
@@ -26,7 +15,7 @@ const DockerImageLink = ({ buildInfo, dockerInfo }: Props) => {
       rel="noreferrer"
       href={
         `https://hub.docker.com/repository/docker/${imageRepo}/${imageName}/tags` +
-        `?page=1&ordering=last_updated&name=${filterTag}`
+        `?page=1&ordering=last_updated&name=${imageTag}`
       }
     >
       <SiDocker />


### PR DESCRIPTION
#### Changes

- Add a button that can only be seen by admins that are logged in. 
- Currently admins are configured in the settings of versioning-backend.

#### Does not include

- calling the endpoint that will trigger the actual build.

#### Screenshots

![image](https://user-images.githubusercontent.com/20756439/109399694-a2bd8b00-7944-11eb-8626-65e368cee923.png)


#### Checklist

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [ ] Readme (updated or not needed)
- [ ] Tests (added, updated or not needed)
