### PR TITLE
Fix a bug where hooks weren't always reached

### DIFF
--- a/components/docs/versions/docker-image-link-or-retry-button.tsx
+++ b/components/docs/versions/docker-image-link-or-retry-button.tsx
@@ -30,13 +30,12 @@ const DockerImageLinkOrRetryButton = ({ record }: Props) => {
   const imageTag = `${baseOs}-${editorVersion}-${targetPlatform}-${repoVersion}`;
 
   const [retryRequested, setRetryRequested] = useState<boolean>(false);
+  const notify = useNotification();
+  const retryBuild = useAuthenticatedEndpoint('retryBuild', { buildId, relatedJobId });
 
   if (dockerInfo) {
     return <DockerImageLink imageRepo={imageRepo} imageName={imageName} imageTag={imageTag} />;
   }
-
-  const notify = useNotification();
-  const retryBuild = useAuthenticatedEndpoint('retryBuild', { buildId, relatedJobId });
 
   const onClick = async () => {
     try {


### PR DESCRIPTION
#### Changes

- Fix a bug where hooks weren't always reached inside `<DockerImageLinkOrRetryButton />`

#### Checklist

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [ ] Tests (added, updated or not needed)
