### PR TITLE
Add blockquote mapping to markdown mapper

### DIFF
--- a/components/markdown/components/blockquote.module.css
+++ b/components/markdown/components/blockquote.module.css
@@ -1,0 +1,8 @@
+.blockquote {
+  font-style: italic;
+  border-left-color: rgba(0, 0, 0, 0.3) !important;
+}
+
+.blockquote :global(.ant-typography) {
+  color: rgba(0, 0, 0, 0.6);
+}

--- a/components/markdown/components/blockquote.tsx
+++ b/components/markdown/components/blockquote.tsx
@@ -1,0 +1,13 @@
+import { ReactNodeLike } from 'prop-types';
+import React from 'react';
+import styles from './blockquote.module.css';
+
+interface Props {
+  children: ReactNodeLike;
+}
+
+const Blockquote = ({ children }: Props) => {
+  return <blockquote className={styles.blockquote}>{children}</blockquote>;
+};
+
+export default Blockquote;

--- a/components/markdown/markdown-to-page-mapping.js
+++ b/components/markdown/markdown-to-page-mapping.js
@@ -1,4 +1,5 @@
 import { Typography, Divider } from 'antd';
+import Blockquote from './components/blockquote';
 
 import CodeBlock from './components/code-block';
 import { List, ListItem } from './components/list';
@@ -15,7 +16,7 @@ export default {
   list: List,
   listItem: ListItem,
   code: CodeBlock,
-  // blockquote: Blockquote, // ' - Block quote (<blockquote>)',
+  blockquote: Blockquote,
   // link: ' - Link (<a>)',
   // image: ' - Image (<img>)',
   // linkReference: ' - Link (through a reference) (<a>)',


### PR DESCRIPTION
#### Changes

- Fixes #68 (add blockquotes rendering from markdown documents)

![image](https://user-images.githubusercontent.com/20756439/109436825-c7d3fb80-7a21-11eb-91db-f33830e29919.png)

#### Checklist

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [ ] Tests (added, updated or not needed)
