### PR TITLE
Use deploy instead of release

### DIFF
--- a/docs/github/v2/15-deployment/android.md
+++ b/docs/github/v2/15-deployment/android.md
@@ -1,4 +1,4 @@
-# Release to Google Play
+# Deploy to Google Play
 
 ### 1- Install fastlane
 
@@ -121,8 +121,8 @@ releaseToGooglePlay:
 ### 5- Add secrets to your Github repo
 
 - **ANDROID_KEYSTORE_BASE64** : Base64 of your keystore in step 1 (You can use an online base64 encoder for this)
-- **ANDROID_KEYSTORE_PASS**: Password of your keystore
-- **ANDROID_KEYALIAS_NAME**: Alias name of your keystore
-- **ANDROID_KEYALIAS_PASS**: Password for your alias name in your keystore
+- **ANDROID_KEYSTORE_PASS**: Password for your keystore
+- **ANDROID_KEYALIAS_NAME**: Name of the alias in your keystore
+- **ANDROID_KEYALIAS_PASS**: Password for the alias in your keystore
 - **GOOGLE_PLAY_KEY_FILE**: Your google account service .json file downloaded from step 2
 - **ANDROID_PACKAGE_NAME**: Your application package name e.g com.company.application

--- a/docs/github/v2/15-deployment/ios.md
+++ b/docs/github/v2/15-deployment/ios.md
@@ -1,4 +1,4 @@
-# Release to the App Store
+# Deploy to the App Store
 
 Uploading to the App Store is a little tricky. Make sure you do all these steps carefully.
 


### PR DESCRIPTION
#### Changes

- Use deploy instead of release and Also further refining the android keystore options

#### Checklist

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
