### PR TITLE
Remove ant icons lib

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -9,15 +9,6 @@
         "libraryDirectory": "lib",
         "style": "index.css"
       }
-    ],
-    [
-      "import",
-      {
-        "libraryName": "@ant-design/icons",
-        "libraryDirectory": "lib/icons",
-        "camel2DashComponentName": false
-      },
-      "@ant-design/icons"
     ]
   ]
 }

--- a/components/layout/docs/edit-on-github-link.tsx
+++ b/components/layout/docs/edit-on-github-link.tsx
@@ -1,5 +1,5 @@
 import { PageContext } from '@/components/context/page-context';
-import { GithubOutlined } from '@ant-design/icons';
+import { AiOutlineGithub } from 'react-icons/all';
 import { useContext } from 'react';
 
 const EditOnGithubLink = () => {
@@ -13,7 +13,7 @@ const EditOnGithubLink = () => {
 
   return (
     <a href={href} type="link">
-      <GithubOutlined />
+      <AiOutlineGithub />
       <span style={{ paddingLeft: 8 }}>Edit on GitHub</span>
     </a>
   );

--- a/components/layout/docs/menu-sidebar.js
+++ b/components/layout/docs/menu-sidebar.js
@@ -2,13 +2,13 @@ import React from 'react';
 import { Menu, Layout } from 'antd';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { QuestionCircleOutlined } from '@ant-design/icons';
 import {
   SiTravisci,
   SiGithubactions,
   SiGitlab,
   AiOutlineInfoCircle,
   SiDocker,
+  AiOutlineQuestionCircle,
 } from 'react-icons/all';
 import VersionedSubMenu from './menu/versioned-sub-menu';
 
@@ -50,7 +50,7 @@ const MenuSidebar = () => {
           key="troubleshooting"
           section="troubleshooting"
           title="Troubleshooting"
-          icon={<QuestionCircleOutlined />}
+          icon={<AiOutlineQuestionCircle />}
         />
       </Menu>
     </Sider>

--- a/components/layout/header/source-links.tsx
+++ b/components/layout/header/source-links.tsx
@@ -1,19 +1,19 @@
 import React from 'react';
-import { GithubOutlined, GitlabOutlined } from '@ant-design/icons';
+import { AiOutlineGithub, AiOutlineGitlab } from 'react-icons/all';
 import { Menu } from 'antd';
 
 const { Item, ItemGroup, SubMenu } = Menu;
 
 // eslint-disable-next-line unicorn/prevent-abbreviations
 const SourceLinks = (props) => (
-  <SubMenu {...props} selectable={false} icon={<GithubOutlined />} title="Source code">
+  <SubMenu {...props} selectable={false} icon={<AiOutlineGithub />} title="Source code">
     <ItemGroup title="Project">
-      <Item icon={<GithubOutlined />} key="source:documentation">
+      <Item icon={<AiOutlineGithub />} key="source:documentation">
         <a target="_blank" rel="noreferrer" href="https://github.com/game-ci/documentation">
           This Website
         </a>
       </Item>
-      <Item icon={<GitlabOutlined />} key="external:example:gitlab">
+      <Item icon={<AiOutlineGitlab />} key="external:example:gitlab">
         <a
           target="_blank"
           rel="noreferrer"
@@ -24,39 +24,43 @@ const SourceLinks = (props) => (
       </Item>
     </ItemGroup>
     <ItemGroup title="Docker">
-      <Item icon={<GithubOutlined />} key="external:unityci:editor">
+      <Item icon={<AiOutlineGithub />} key="external:unityci:editor">
         <a target="_blank" rel="noreferrer" href="https://hub.docker.com/r/unityci/editor">
           unityci/editor
         </a>
       </Item>
     </ItemGroup>
     <ItemGroup title="GitHub Actions">
-      <Item icon={<GithubOutlined />} key="external:action:overview">
+      <Item icon={<AiOutlineGithub />} key="external:action:overview">
         <a target="_blank" rel="noreferrer" href="https://github.com/game-ci/unity-actions">
           Unity Actions
         </a>
       </Item>
-      <Item icon={<GithubOutlined />} key="external:action:request-activation-file">
-        <a target="_blank" rel="noreferrer" href="https://github.com/game-ci/unity-request-activation-file">
+      <Item icon={<AiOutlineGithub />} key="external:action:request-activation-file">
+        <a
+          target="_blank"
+          rel="noreferrer"
+          href="https://github.com/game-ci/unity-request-activation-file"
+        >
           Unity Request Activation
         </a>
       </Item>
-      <Item icon={<GithubOutlined />} key="external:action:activate">
+      <Item icon={<AiOutlineGithub />} key="external:action:activate">
         <a target="_blank" rel="noreferrer" href="https://github.com/game-ci/unity-activate">
           Unity Activate
         </a>
       </Item>
-      <Item icon={<GithubOutlined />} key="external:action:test-runner">
+      <Item icon={<AiOutlineGithub />} key="external:action:test-runner">
         <a target="_blank" rel="noreferrer" href="https://github.com/game-ci/unity-test-runner">
           Unity Test Runner
         </a>
       </Item>
-      <Item icon={<GithubOutlined />} key="external:action:builder">
+      <Item icon={<AiOutlineGithub />} key="external:action:builder">
         <a target="_blank" rel="noreferrer" href="https://github.com/game-ci/unity-builder">
           Unity Builder
         </a>
       </Item>
-      <Item icon={<GithubOutlined />} key="external:action:return-license">
+      <Item icon={<AiOutlineGithub />} key="external:action:return-license">
         <a target="_blank" rel="noreferrer" href="https://github.com/game-ci/unity-return-license">
           Unity Return License
         </a>

--- a/components/layout/main/breadcrumb.js
+++ b/components/layout/main/breadcrumb.js
@@ -3,7 +3,7 @@ import { MenuSegment } from '@/tools/menu/menu-segment';
 import { MenuStructure } from '@/tools/menu/menu-structure';
 import Link from 'next/link';
 import { Breadcrumb } from 'antd';
-import { HomeOutlined } from '@ant-design/icons';
+import { AiOutlineHome } from 'react-icons/all';
 import usePathSegments from '@/core/routing/use-path-segments';
 import { useContext } from 'react';
 import MenuContext from '../docs/menu/menu-context';
@@ -11,7 +11,7 @@ import MenuContext from '../docs/menu/menu-context';
 const { Item } = Breadcrumb;
 
 const BreadcrumbWrapper = () => {
-  const segments = usePathSegments(<HomeOutlined />);
+  const segments = usePathSegments(<AiOutlineHome />);
   const { menuStructure } = useContext(MenuContext);
 
   return (

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "start": "next start"
   },
   "dependencies": {
-    "@ant-design/icons": "4.4.0",
     "@next/bundle-analyzer": "^10.0.6",
     "@reduxjs/toolkit": "^1.5.0",
     "@types/lodash": "^4.14.168",

--- a/pages/example.js
+++ b/pages/example.js
@@ -1,5 +1,5 @@
 import { Form, Select, InputNumber, Switch, Slider, Button, Typography } from 'antd';
-import { SmileFilled } from '@ant-design/icons';
+import { AiFillSmile } from 'react-icons/all';
 import Link from 'next/link';
 
 import DocumentationPage from '@/components/layout/docs/page';
@@ -18,7 +18,7 @@ export default function Page() {
             <a>
               <Title>
                 title
-                <SmileFilled size={48} strokeWidth={1} />
+                <AiFillSmile size={48} strokeWidth={1} />
               </Title>
             </a>
           </Link>

--- a/yarn.lock
+++ b/yarn.lock
@@ -169,7 +169,7 @@
   resolved "https://registry.yarnpkg.com/@ant-design/icons-svg/-/icons-svg-4.1.0.tgz#480b025f4b20ef7fe8f47d4a4846e4fee84ea06c"
   integrity sha512-Fi03PfuUqRs76aI3UWYpP864lkrfPo0hluwGqh7NJdLhvH4iRDc3jbJqZIvRDLHKbXrvAfPPV3+zjUccfFvWOQ==
 
-"@ant-design/icons@4.4.0", "@ant-design/icons@^4.4.0":
+"@ant-design/icons@^4.4.0":
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/@ant-design/icons/-/icons-4.4.0.tgz#d4e4ba5910454e1d3f67a802d2aad9ee75a51dea"
   integrity sha512-+X44IouK56JbP3r7zM+Zoykv5wQlXBlxY0NTaFXGpiyYSS/Bh6HIo9aTF62QkSuDTqA3UpeNVTRFioKKRmkWDQ==


### PR DESCRIPTION
#### Changes

- Convert all icons to use `react-icons` instead of `@ant-design/icons`
- Remove ant icons library from package.json and babel.

This should simplify moving toward ant with less support.

#### Checklist

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
