### PR TITLE
Improve examples

### DIFF
--- a/docs/github/v2/01-getting-started.md
+++ b/docs/github/v2/01-getting-started.md
@@ -58,12 +58,7 @@ This example assumes that your Unity project is in the root of your repository.
 ```yaml
 name: Actions 😎
 
-on:
-  pull_request: {}
-  push: { branches: [main] }
-
-env:
-  UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+on: [push, pull_request]
 
 jobs:
   build:
@@ -85,12 +80,16 @@ jobs:
       # Test
       - name: Run tests
         uses: game-ci/unity-test-runner@v2
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
 
       # Build
       - name: Build project
         uses: game-ci/unity-builder@v2
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
         with:
           targetPlatform: WebGL
 
@@ -109,12 +108,7 @@ have a look at the example below.
 ```yaml
 name: Actions 😎
 
-on:
-  pull_request: {}
-  push: { branches: [main] }
-
-env:
-  UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+on: [push, pull_request]
 
 jobs:
   buildAndTestForSomePlatforms:
@@ -149,6 +143,8 @@ jobs:
             Library-
       - uses: game-ci/unity-test-runner@v2
         id: testRunner
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
         with:
           projectPath: ${{ matrix.projectPath }}
           unityVersion: ${{ matrix.unityVersion }}
@@ -159,6 +155,8 @@ jobs:
           name: Test results (all modes)
           path: ${{ steps.testRunner.outputs.artifactsPath }}
       - uses: game-ci/unity-builder@v2
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
         with:
           projectPath: ${{ matrix.projectPath }}
           unityVersion: ${{ matrix.unityVersion }}

--- a/docs/github/v2/03-test-runner.md
+++ b/docs/github/v2/03-test-runner.md
@@ -231,14 +231,9 @@ _**default:** `""`_
 A complete workflow that tests all modes separately could look like this:
 
 ```yaml
-name: Build project
+name: Test project
 
-on:
-  pull_request: {}
-  push: { branches: [main] }
-
-env:
-  UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+on: [push, pull_request]
 
 jobs:
   testAllModes:
@@ -264,6 +259,8 @@ jobs:
             Library-
       - uses: game-ci/unity-test-runner@v2
         id: tests
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
         with:
           projectPath: ${{ matrix.projectPath }}
           testMode: ${{ matrix.testMode }}
@@ -276,5 +273,3 @@ jobs:
           name: Test results for ${{ matrix.testMode }}
           path: ${{ steps.tests.outputs.artifactsPath }}
 ```
-
-> _**Note:** Environment variables are set for all jobs in the workflow like this._

--- a/docs/github/v2/04-builder.md
+++ b/docs/github/v2/04-builder.md
@@ -337,12 +337,7 @@ A complete workflow that builds every available platform could look like this:
 ```yaml
 name: Build project
 
-on:
-  pull_request: {}
-  push: { branches: [main] }
-
-env:
-  UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+on: [push, pull_request]
 
 jobs:
   buildForAllSupportedPlatforms:
@@ -370,6 +365,8 @@ jobs:
           key: Library-${{ matrix.targetPlatform }}
           restore-keys: Library-
       - uses: game-ci/unity-builder@v2
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
         with:
           targetPlatform: ${{ matrix.targetPlatform }}
       - uses: actions/upload-artifact@v2
@@ -377,5 +374,3 @@ jobs:
           name: Build-${{ matrix.targetPlatform }}
           path: build/${{ matrix.targetPlatform }}
 ```
-
-> **Note:** _Environment variables are set for all jobs in the workflow like this._


### PR DESCRIPTION
Encourage running CI on every push and pull request, and keep the environment localized to where they are needed, to reduce risk of them being leaked to a bad action.

#### Changes

- Use `on: [push, pull_request]`
- Localize environment variables to where they are needed

#### Checklist

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
