### PR TITLE
Use width and height to fix huge scroll bug

### DIFF
--- a/components/layout/header/nav-bar.tsx
+++ b/components/layout/header/nav-bar.tsx
@@ -16,7 +16,7 @@ interface Props {
 const NavBar = ({ showSearch }: Props) => (
   <Header className="header">
     <a className="logo" href="/">
-      <GameCiLogo width="60" />
+      <GameCiLogo width="60" height="60" />
     </a>
     <Menu
       theme="dark"


### PR DESCRIPTION
Bug introduced in following pr/discussion:  https://github.com/game-ci/documentation/pull/151#discussion_r624682949

Before:

<img width="709" alt="image" src="https://user-images.githubusercontent.com/1264761/116821289-4561d800-ab47-11eb-9a1a-863384234cb8.png">

After:

<img width="1008" alt="image" src="https://user-images.githubusercontent.com/1264761/116821603-90301f80-ab48-11eb-8b2e-3a2e4ff92d47.png">


This was caused by not specifying height and width. Usually, we're able to only specify `width` and height is calculated automatically, but maybe it's different with svgs.