### PR TITLE
Remove console from syntax highlighting

### DIFF
--- a/components/markdown/components/code-block.js
+++ b/components/markdown/components/code-block.js
@@ -9,6 +9,7 @@ hljs.registerLanguage('typescript', require('highlight.js/lib/languages/typescri
 hljs.registerLanguage('bash', require('highlight.js/lib/languages/bash'));
 hljs.registerLanguage('ruby', require('highlight.js/lib/languages/ruby'));
 hljs.registerLanguage('powershell', require('highlight.js/lib/languages/powershell'));
+hljs.registerLanguage('plaintext', require('highlight.js/lib/languages/plaintext'));
 
 class CodeBlock extends React.PureComponent {
   constructor(properties) {

--- a/docs/troubleshooting/common-issues.md
+++ b/docs/troubleshooting/common-issues.md
@@ -8,7 +8,7 @@ Below you'll find a collection of answers to commonly reported problems.
 
 #### Error
 
-```
+```plaintext
 Scripts have compiler errors.
 (Filename: ./Runtime/Utilities/Argv.cpp Line: 361)
 
@@ -33,7 +33,7 @@ A good way to verify this, is to (locally) clone the Unity project in a new fold
 
 #### Error
 
-```
+```plaintext
 Error: 3.690 [ERROR] [org.gradle.launcher.daemon.server.DaemonStateCoordinator] Command execution: started DaemonCommandExecution[command = Build{id=69dbd5b3-10f2-488e-8640-977da68733f9, currentDir=/github/workspace/Temp/gradleOut/launcher}, connection = DefaultDaemonConnection: socket connection from /127.0.0.1:33657 to /127.0.0.1:43866] after 0.0 minutes of idle
 ```
 

--- a/docs/troubleshooting/common-issues.md
+++ b/docs/troubleshooting/common-issues.md
@@ -8,7 +8,7 @@ Below you'll find a collection of answers to commonly reported problems.
 
 #### Error
 
-```console
+```
 Scripts have compiler errors.
 (Filename: ./Runtime/Utilities/Argv.cpp Line: 361)
 
@@ -33,7 +33,7 @@ A good way to verify this, is to (locally) clone the Unity project in a new fold
 
 #### Error
 
-```console
+```
 Error: 3.690 [ERROR] [org.gradle.launcher.daemon.server.DaemonStateCoordinator] Command execution: started DaemonCommandExecution[command = Build{id=69dbd5b3-10f2-488e-8640-977da68733f9, currentDir=/github/workspace/Temp/gradleOut/launcher}, connection = DefaultDaemonConnection: socket connection from /127.0.0.1:33657 to /127.0.0.1:43866] after 0.0 minutes of idle
 ```
 


### PR DESCRIPTION
About to compare no `console` vs `plaintext` + 
```js
hljs.registerLanguage('plaintext', require('highlight.js/lib/languages/plaintext'));
```