### PR TITLE
Fix PR template links

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,6 @@
 
 <!-- please check all items and add your own -->
 
-- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
+- [ ] Read the contribution [guide](../blob/main/CONTRIBUTING.md) and accept the [code](../blob/main/CODE_OF_CONDUCT.md) of conduct
 - [ ] Readme (updated or not needed)
 - [ ] Tests (added, updated or not needed)


### PR DESCRIPTION
#### Changes

- Changed the links to contributing.md and code_of_conduct.md to point to the files instead of a 404 page

#### Checklist

- [x] Read the contribution [guide](../blob/main/CONTRIBUTING.md) and accept the [code](../blob/main/CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
