### PR TITLE
Resolving dead link

### DIFF
--- a/docs/github/v2/03-test-runner.md
+++ b/docs/github/v2/03-test-runner.md
@@ -72,7 +72,7 @@ If you choose not to provide the `githubToken`, you may still upload the artifac
 To be able to access the test results, they need to be uploaded as artifacts.
 
 To do this, it is recommended to use the official Github Actions
-[upload artifact action](https://github.com/marketplace/actions/upload-artifact).
+[upload artifact action](https://github.com/marketplace/actions/upload-a-build-artifact).
 
 By default, Test Runner outputs its results to a folder named `artifacts`.
 


### PR DESCRIPTION
https://github.com/marketplace/actions/upload-artifact is a 404
https://github.com/marketplace/actions/upload-a-build-artifact is the marketplace link for upload-artifact

#### Changes

- ...

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../blob/main/CONTRIBUTING.md) and accept the [code](../blob/main/CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
