### PR TITLE
Fix yarn build command by updating style pattern regex.

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -13,7 +13,7 @@ const lessNextConfig = {
 
   webpack: (config, options) => {
     if (options.isServer) {
-      const antStylesPattern = /antd\/.*?\/style.*?/;
+      const antStylesPattern = /(antd\/.*?\/style).*(?<!\.js)$/;
       const originalExternals = [...config.externals];
 
       config.externals = [


### PR DESCRIPTION
#### Changes

- Updated next.js `antStylesPattern` to exclude files with a *.js format.

*Error log*:

```
./node_modules/node-fetch/lib/index.js
Module not found: Can't resolve 'encoding' in '/var/www/html/node_modules/node-fetch/lib'


> Build error occurred
/var/www/html/.next/serverless/pages/docs/[...documentation-page].js:1
TypeError: (0 , _styleChecker.canUseDocElement) is not a function
    at Object.sVM9 (/var/www/html/.next/serverless/pages/docs/[...documentation-page].js:311597:40)
    at __webpack_require__ (/var/www/html/.next/serverless/pages/docs/[...documentation-page].js:31:31)
    at Object.CC+v (/var/www/html/.next/serverless/pages/docs/[...documentation-page].js:66495:38)
    at __webpack_require__ (/var/www/html/.next/serverless/pages/docs/[...documentation-page].js:31:31)
    at Object.bmkC (/var/www/html/.next/serverless/pages/docs/[...documentation-page].js:195929:37)
    at __webpack_require__ (/var/www/html/.next/serverless/pages/docs/[...documentation-page].js:31:31)
    at Object.C7EO (/var/www/html/.next/serverless/pages/docs/[...documentation-page].js:65477:11)
    at __webpack_require__ (/var/www/html/.next/serverless/pages/docs/[...documentation-page].js:31:31)
    at Module.1uJF (/var/www/html/.next/serverless/pages/docs/[...documentation-page].js:26269:26)
    at __webpack_require__ (/var/www/html/.next/serverless/pages/docs/[...documentation-page].js:31:31) {
  type: 'TypeError'
}
error Command failed with exit code 1.
```


#### Checklist


- [x] Read the contribution [guide](../blob/main/CONTRIBUTING.md) and accept the [code](../blob/main/CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
