### PR TITLE
Docs examples: Generate unique cache keys

### DIFF
--- a/docs/github/v2/01-getting-started.md
+++ b/docs/github/v2/01-getting-started.md
@@ -141,7 +141,7 @@ jobs:
           path: ${{ matrix.projectPath }}/Library
           key: Library-${{ matrix.projectPath }}-${{ matrix.targetPlatform }}-${{ hashFiles(matrix.projectPath) }}
           restore-keys: |
-            Library-${{ matrix.projectPath }}-${{ matrix.targetPlatform }}
+            Library-${{ matrix.projectPath }}-${{ matrix.targetPlatform }}-
             Library-${{ matrix.projectPath }}-
             Library-
       - uses: game-ci/unity-test-runner@v2

--- a/docs/github/v2/01-getting-started.md
+++ b/docs/github/v2/01-getting-started.md
@@ -75,7 +75,9 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: Library
-          key: Library
+          key: Library-${{ hashFiles('Assets/**', 'Packages/**', 'ProjectSettings/**') }}
+          restore-keys: |
+            Library-
 
       # Test
       - name: Run tests
@@ -137,8 +139,9 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ${{ matrix.projectPath }}/Library
-          key: Library-${{ matrix.projectPath }}-${{ matrix.targetPlatform }}
+          key: Library-${{ matrix.projectPath }}-${{ matrix.targetPlatform }}-${{ hashFiles(matrix.projectPath) }}
           restore-keys: |
+            Library-${{ matrix.projectPath }}-${{ matrix.targetPlatform }}
             Library-${{ matrix.projectPath }}-
             Library-
       - uses: game-ci/unity-test-runner@v2


### PR DESCRIPTION
#### Changes

- Update the GitHub Actions documentation examples to include unique cache keys. If the key is not unique for each build, the cache will only get updated for the first time the job is run. By generating a unique cache key, every time the job is run, a new cache entry will be created, and as per GitHub docs: "If there are no exact matches, the action searches for partial matches of the restore keys. When the action finds a partial match, the most recent cache is restored to the path directory."

I'm not supper happy with how the examples are slightly different for the simple and advanced example. But I feel the simple example is more correct, and the advanced example would get really complex if we did it in a similar way, as it would require using the `format` function (as nested variable substitutions aren't a thing).

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../blob/main/CONTRIBUTING.md) and accept the [code](../blob/main/CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
