### PR TITLE
Add LFS example to GitHub Getting Started guide

### DIFF
--- a/docs/github/v2/01-getting-started.md
+++ b/docs/github/v2/01-getting-started.md
@@ -107,6 +107,72 @@ jobs:
           path: build
 ```
 
+## Simple example with Git LFS
+
+If you are using GitHub's git-lfs hosting service to store your large binary assets, you will want to cache them to avoid consuming massive amounts of bandwidth. The extra steps in this example try to restore your git-lfs assets from a cache before doing a git lfs pull.  
+
+```yaml
+name: Actions 😎
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Build my project ✨
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout (without LFS)
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      # Git LFS
+      - name: Create LFS file list
+        run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
+
+      - name: Restore LFS cache
+        uses: actions/cache@v2
+        id: lfs-cache
+        with:
+          path: .git/lfs
+          key: ${{ runner.os }}-lfs-${{ hashFiles('.lfs-assets-id') }}
+
+      - name: Git LFS Pull
+        run: |
+          git lfs pull
+          git add .
+          git reset --hard
+          
+      # Cache
+      - uses: actions/cache@v2
+        with:
+          path: Library
+          key: Library-${{ hashFiles('Assets/**', 'Packages/**', 'ProjectSettings/**') }}
+          restore-keys: |
+            Library-
+
+      # Test
+      - name: Run tests
+        uses: game-ci/unity-test-runner@v2
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+
+      # Build
+      - name: Build project
+        uses: game-ci/unity-builder@v2
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+        with:
+          targetPlatform: WebGL
+
+      # Output
+      - uses: actions/upload-artifact@v2
+        with:
+          name: Build
+          path: build
+```
+
 ## Advanced example
 
 To get an idea of how to create a more advanced workflows,


### PR DESCRIPTION
#### Changes

Hi!

The "simple" workflow example for the [GH getting started guide](https://game.ci/docs/github/getting-started) includes a git-lfs pull as part of checkout, but doesn't warn people that this will eat up their data pack bandwidth. 

This PR adds a short explanation of the problem, as well as an extra example workflow that includes git-lfs caching (with steps taken directly from the reference project workflow: https://github.com/webbertakken/unity-reference-project/blob/main/.github/workflows/main.yml).

I'm open to alternatives, but since Git LFS is such a common use case, it seems important to flag early on to new users that this is a real problem with an easy solution. 

Thanks! :)

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../blob/main/CONTRIBUTING.md) and accept the [code](../blob/main/CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
