### PR TITLE
Updated CodeBlock properties

### DIFF
--- a/components/docs/versions/build-failure-details.tsx
+++ b/components/docs/versions/build-failure-details.tsx
@@ -1,6 +1,7 @@
 import CodeBlock from '@/components/markdown/components/code-block';
 import Heading from '@/components/markdown/components/heading';
 import React, { useReducer } from 'react';
+import Article from '@/components/markdown/components/article';
 
 interface Props {
   ciJob;
@@ -58,20 +59,20 @@ const BuildFailureDetails = ({
     `--build-arg=module=${targetPlatform}`;
 
   return (
-    <article {...rest}>
+    <Article {...rest}>
       <Heading level={4}>CI Job</Heading>
       <pre>{JSON.stringify(ciJob, null, 2)}</pre>
       <br />
       <Heading level={4}>Commands</Heading>
       <p>To manually build for debugging:</p>
-      <CodeBlock value={command} language="powershell" />
+      <CodeBlock language="powershell">{[command]}</CodeBlock>
       <br />
       <Heading level={3}>Associated tags</Heading>
       <pre>{JSON.stringify(tags, null, 2)}</pre>
       <br />
       <Heading level={4}>CI Build</Heading>
       <pre>{JSON.stringify(ciBuild, null, 2)}</pre>
-    </article>
+    </Article>
   );
 };
 


### PR DESCRIPTION
#### Changes

- Fixes #211 
- Using the Article component for the `build-failure-details.tsx` to maintain a consistent style

#### Possible new issue
While changing this, I got confused, cause `code-block.js` defines its children property as a string (`children: PropTypes.string.isRequired`) but on the clipboard copy it accesses it with`children[0]`. 

But without casting it to an array it will only copy the first letter to the clipboard. Might be worth creating a new issue for this and investigate if it's possible to change. 

Following warning will be thrown
> Warning: Failed prop type: Invalid prop `children` of type `array` supplied to `CodeBlock`, expected `string`.

This warning is thrown on all pages that make use of the CodeBlock component. 

#### Screenshot
Screenshot for easy comparison of the visual changes:

![compare](https://user-images.githubusercontent.com/34155528/135848832-44b610db-98e3-46cd-9505-b7282ef23b82.png)

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../blob/main/CONTRIBUTING.md) and accept the [code](../blob/main/CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
