### PR TITLE
Remove APPLE_TEAM_NAME from iOS docs

### DIFF
--- a/docs/github/v2/15-deployment/ios.md
+++ b/docs/github/v2/15-deployment/ios.md
@@ -180,7 +180,6 @@ jobs:
           APPLE_CONNECT_EMAIL: ${{ secrets.APPLE_CONNECT_EMAIL }}
           APPLE_DEVELOPER_EMAIL: ${{ secrets.APPLE_DEVELOPER_EMAIL }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          APPLE_TEAM_NAME: ${{ secrets.APPLE_TEAM_NAME }}
           MATCH_URL: ${{ secrets.MATCH_URL }}
           MATCH_PERSONAL_ACCESS_TOKEN: ${{ secrets.MATCH_PERSONAL_ACCESS_TOKEN }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
@@ -206,7 +205,6 @@ jobs:
 - **APPLE_CONNECT_EMAIL**: Apple connect email (usually same as APPLE_DEVELOPER_EMAIL)
 - **APPLE_DEVELOPER_EMAIL**: Your AppleId
 - **APPLE_TEAM_ID**: Team Id from your [Apple Developer Account - Membership Details](https://developer.apple.com/account/#/membership/)
-- **APPLE_TEAM_NAME**: Team Name from your [Apple Developer Account - Membership Details](https://developer.apple.com/account/#/membership/)
 - **MATCH_URL**: Https url for the private git repo to which `fastlane match appstore` uploaded certificates.
 - **MATCH_PERSONAL_ACCESS_TOKEN**: GitHub [Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) with full repo access to MATCH_URL
 - **MATCH_PASSWORD**: The password you set with `fastlane match appstore`


### PR DESCRIPTION
Looks like we're using `itc_team_id(ENV['APPLE_TEAM_ID'])` in `Appfile` so we don't have to specify the `APPLE_TEAM_NAME` env var which was previously passed to `itc_team_name` if I'm not mistaken.

I'm in the process of automating one of my iOS apps with fastlane and looks like we don't use `APPLE_TEAM_NAME` anywhere.

Less is more! :tada: