### PR TITLE
Update documentation links to point to gitlab org and main

### DIFF
--- a/components/layout/header/source-links.tsx
+++ b/components/layout/header/source-links.tsx
@@ -22,7 +22,7 @@ const SourceLinks = (props) => (
         <a
           target="_blank"
           rel="noreferrer"
-          href="https://gitlab.com/gableroux/unity3d-gitlab-ci-example"
+          href="https://gitlab.com/game-ci/unity3d-gitlab-ci-example"
         >
           Example CI project
         </a>

--- a/docs/docker/01-docker-images.md
+++ b/docs/docker/01-docker-images.md
@@ -6,7 +6,7 @@ docker images which are specialised for CI and command-line use. These images ar
 [docker hub as `unityci/editor`](https://hub.docker.com/r/unityci/editor/tags?page=1&ordering=last_updated).
 
 They are established empirically by the community and come forth from the
-[`gableroux/unity3d`](https://gitlab.com/gableroux/unity3d/)
+[`gableroux/unity3d`](https://gitlab.com/game-ci/unity3d/)
 project. It was previously published on
 [docker hub as `gableroux/unity3d`](https://hub.docker.com/r/gableroux/unity3d/).
 **There won't be any new versions releases for `gableroux/unity3d` as it is now deprecated in favor of

--- a/docs/github/v1/01-getting-started.md
+++ b/docs/github/v1/01-getting-started.md
@@ -45,7 +45,7 @@ Any subsequent steps assume you have read the above.
 #### Supported versions
 
 Unity Actions are based on the
-[unity3d](https://gitlab.com/gableroux/unity3d)
+[unity3d](https://gitlab.com/game-ci/unity3d)
 images from
 [GabLeRoux](https://github.com/GabLeRoux).
 Any version in the

--- a/docs/gitlab/01-getting-started.md
+++ b/docs/gitlab/01-getting-started.md
@@ -18,7 +18,7 @@ Any subsequent steps assume you have read the above.
 
 ## Supported versions
 
-The [unity3d-gitlab-ci-example project](https://gitlab.com/gableroux/unity3d-gitlab-ci-example/) is based on [unity3d](https://github.com/game-ci/docker/) docker images from [game-ci](https://github.com/game-ci). Any version in the [docker hub `unityci/editor` tags list](https://hub.docker.com/r/unityci/editor/tags) can be used to test and build projects.
+The [unity3d-gitlab-ci-example project](https://gitlab.com/game-ci/unity3d-gitlab-ci-example/) is based on [unity3d](https://github.com/game-ci/docker/) docker images from [game-ci](https://github.com/game-ci). Any version in the [docker hub `unityci/editor` tags list](https://hub.docker.com/r/unityci/editor/tags) can be used to test and build projects.
 
 It's generally considered good practice to use the same Unity version for your CI/CD setup as you do to develop your project.
 
@@ -30,14 +30,14 @@ https://www.youtube-nocookie.com/embed/k0NcedDzEqA
 
 ### I don't have a Unity project yet
 
-1. Fork [the unity3d-gitlab-ci-example project](https://gitlab.com/gableroux/unity3d-gitlab-ci-example/)
+1. Fork [the unity3d-gitlab-ci-example project](https://gitlab.com/game-ci/unity3d-gitlab-ci-example/)
 1. Clone the fork you just created locally
 1. Continue to activation instructions
 
 ### I already have my own Unity project
 
-1. Clone [the unity3d-gitlab-ci-example project](https://gitlab.com/gableroux/unity3d-gitlab-ci-example/)
-1. Copy [`.gitlab-ci.yml`](https://gitlab.com/gableroux/unity3d-gitlab-ci-example/-/blob/master/.gitlab-ci.yml) to the root of your repository, [`Assets/Scripts/Editor/BuildCommand.cs`](https://gitlab.com/gableroux/unity3d-gitlab-ci-example/-/blob/master/Assets/Scripts/Editor/BuildCommand.cs) and [`ci` folder](https://gitlab.com/gableroux/unity3d-gitlab-ci-example/-/blob/master/ci) to your project:
+1. Clone [the unity3d-gitlab-ci-example project](https://gitlab.com/game-ci/unity3d-gitlab-ci-example/)
+1. Copy [`.gitlab-ci.yml`](https://gitlab.com/game-ci/unity3d-gitlab-ci-example/-/blob/main/.gitlab-ci.yml) to the root of your repository, [`Assets/Scripts/Editor/BuildCommand.cs`](https://gitlab.com/game-ci/unity3d-gitlab-ci-example/-/blob/main/Assets/Scripts/Editor/BuildCommand.cs) and [`ci` folder](https://gitlab.com/game-ci/unity3d-gitlab-ci-example/-/blob/main/ci) to your project:
 
    Assuming you've cloned the example project in the parent folder of your project, and your Unity project is at the root of your repository, execute these commands from the root folder of your project:
 
@@ -48,6 +48,6 @@ https://www.youtube-nocookie.com/embed/k0NcedDzEqA
    cp ../unity3d-gitlab-ci-example/Assets/Scripts/Editor/BuildCommand.cs ./Assets/Scripts/Editor/
    ```
 
-1. Open and edit the [`.gitlab-ci.yml`](https://gitlab.com/gableroux/unity3d-gitlab-ci-example/-/blob/master/.gitlab-ci.yml) you copied to your project and update [the variables](https://gitlab.com/gableroux/unity3d-gitlab-ci-example/-/blob/master/.gitlab-ci.yml#L7-13) with the versions you need. Your Unity project version can be found in `ProjectSettings/ProjectVersion.txt`.
+1. Open and edit the [`.gitlab-ci.yml`](https://gitlab.com/game-ci/unity3d-gitlab-ci-example/-/blob/main/.gitlab-ci.yml) you copied to your project and update [the variables](https://gitlab.com/game-ci/unity3d-gitlab-ci-example/-/blob/main/.gitlab-ci.yml#L7-13) with the versions you need. Your Unity project version can be found in `ProjectSettings/ProjectVersion.txt`.
 1. If your Unity project is not at the root of your repository, also update UNITY_DIR variable.
 1. Continue to activation instructions

--- a/docs/gitlab/02-activation.md
+++ b/docs/gitlab/02-activation.md
@@ -6,7 +6,7 @@ There are a few methods available, if you're using gitlab-ci, the easiest method
 
 ### a. Using gitlab-ci
 
-Once you've added all required files to your project (mainly [`.gitlab-ci.yml`](https://gitlab.com/gableroux/unity3d-gitlab-ci-example/-/blob/master/.gitlab-ci.yml)), there should be a manual step that can be triggered for activation.
+Once you've added all required files to your project (mainly [`.gitlab-ci.yml`](https://gitlab.com/game-ci/unity3d-gitlab-ci-example/-/blob/main/.gitlab-ci.yml)), there should be a manual step that can be triggered for activation.
 
 1. Visit your project's settings > CI/CD > Variables and add `UNITY_USERNAME` and `UNITY_PASSWORD` with your credentials. Make sure to use your Unity3d _email address_ for `UNITY_USERNAME`.
 1. Push your first commit to your project and visit CI/CD Pipelines.
@@ -67,15 +67,15 @@ All you need is [docker](https://www.docker.com/) installed on your machine.
 
    > Can't activate Unity: No sufficient permissions while processing request HTTP error code 401
 
-   Make sure your credentials are valid. You may try to disable 2FA in your account and try again. Once done, you should enable 2FA again for security reasons. See [#11](https://gitlab.com/gableroux/unity3d-gitlab-ci-example/issues/11) for more details.
+   Make sure your credentials are valid. You may try to disable 2FA in your account and try again. Once done, you should enable 2FA again for security reasons. See [#11](https://gitlab.com/game-ci/unity3d-gitlab-ci-example/issues/11) for more details.
 
 5. Copy xml content and save as `unity3d.alf`
 6. Open https://license.unity3d.com/manual and answer questions
 7. Upload `unity3d.alf` for manual activation
 8. Download `Unity_v2018.x.ulf` (`Unity_v2019.x.ulf` for 2019 versions)
 9. Copy the content of `Unity_v2018.x.ulf` license file to your CI's environment variable `UNITY_LICENSE`.
-   _Note: if you are doing this on Windows, chances are the [line endings will be wrong as explained here](https://gitlab.com/gableroux/unity3d-gitlab-ci-example/issues/5#note_95831816). Luckily for you, [`.gitlab-ci.yml`](https://github.com/game-ci/unity3d-ci-example/blob/master/.gitlab-ci.yml) of the example project solves this by removing `\r` character from the ENV variable so you'll be alright_
-   [`.gitlab-ci.yml`](https://gitlab.com/gableroux/unity3d-gitlab-ci-example/-/blob/master/.gitlab-ci.yml) will then place the `UNITY_LICENSE` to the right place before running tests or creating the builds.
+   _Note: if you are doing this on Windows, chances are the [line endings will be wrong as explained here](https://gitlab.com/game-ci/unity3d-gitlab-ci-example/issues/5#note_95831816). Luckily for you, [`.gitlab-ci.yml`](https://github.com/game-ci/unity3d-ci-example/blob/main/.gitlab-ci.yml) of the example project solves this by removing `\r` character from the ENV variable so you'll be alright_
+   [`.gitlab-ci.yml`](https://gitlab.com/game-ci/unity3d-gitlab-ci-example/-/blob/main/.gitlab-ci.yml) will then place the `UNITY_LICENSE` to the right place before running tests or creating the builds.
 
 ## Unity Plus/Pro
 
@@ -115,5 +115,5 @@ All you need is [docker](https://www.docker.com/) installed on your machine.
 4. Wait for the command to finish without errors
 5. Obtain the contents of the license file by running `cat /root/.local/share/unity3d/Unity/Unity_lic.ulf`
 6. Copy the content to your CI's environment variable `UNITY_LICENSE`.
-   _Note: if you are doing this on windows, chances are the [line endings will be wrong as explained here](https://gitlab.com/gableroux/unity3d-gitlab-ci-example/issues/5#note_95831816). Luckily for you, [`.gitlab-ci.yml`](https://gitlab.com/gableroux/unity3d-gitlab-ci-example/-/blob/master/.gitlab-ci.yml) solves this by removing `\r` character from the env variable so you'll be alright_
-   [`.gitlab-ci.yml`](https://gitlab.com/gableroux/unity3d-gitlab-ci-example/-/blob/master/.gitlab-ci.yml) will then place the `UNITY_LICENSE` to the right place before running tests or creating the builds.
+   _Note: if you are doing this on windows, chances are the [line endings will be wrong as explained here](https://gitlab.com/game-ci/unity3d-gitlab-ci-example/issues/5#note_95831816). Luckily for you, [`.gitlab-ci.yml`](https://gitlab.com/game-ci/unity3d-gitlab-ci-example/-/blob/main/.gitlab-ci.yml) solves this by removing `\r` character from the env variable so you'll be alright_
+   [`.gitlab-ci.yml`](https://gitlab.com/game-ci/unity3d-gitlab-ci-example/-/blob/main/.gitlab-ci.yml) will then place the `UNITY_LICENSE` to the right place before running tests or creating the builds.

--- a/docs/gitlab/03-example-project.md
+++ b/docs/gitlab/03-example-project.md
@@ -2,16 +2,16 @@
 
 ## About
 
-[The `unity3d-gitlab-ci-example` project](https://gitlab.com/gableroux/unity3d-gitlab-ci-example/) uses an updated version of the [Unity's Creator Kit: RPG free asset](https://assetstore.unity.com/packages/templates/tutorials/creator-kit-rpg-149309) which is not affiliated with this project at all. Feel free to explore it, dialogs are a bit different ;)
+[The `unity3d-gitlab-ci-example` project](https://gitlab.com/game-ci/unity3d-gitlab-ci-example/) uses an updated version of the [Unity's Creator Kit: RPG free asset](https://assetstore.unity.com/packages/templates/tutorials/creator-kit-rpg-149309) which is not affiliated with this project at all. Feel free to explore it, dialogs are a bit different ;)
 
 The example project is a Proof of Concept to **run unity3d tests and builds inside a CI** using **[game-ci/docker unity editor docker images](https://github.com/game-ci/docker)**. It currently creates builds for Windows, Linux, MacOS, webgl, Linux IL2cpp, Android and iOS Xcode project. The webgl build is published by the CI to [gitlab-pages](https://about.gitlab.com/features/pages/). **You can try the built project on [the published gitlab-pages](https://gableroux.gitlab.io/unity3d-gitlab-ci-example/)**.
 
 ## Git remotes
 
-[The `unity3d-gitlab-ci-example` project](https://gitlab.com/gableroux/unity3d-gitlab-ci-example/) is hosted on multiple remotes to provide examples for [Gitlab-CI](https://about.gitlab.com/product/continuous-integration/), [Travis CI](https://travis-ci.org/) and [CircleCI](https://circleci.com/)
+[The `unity3d-gitlab-ci-example` project](https://gitlab.com/game-ci/unity3d-gitlab-ci-example/) is hosted on multiple remotes to provide examples for [Gitlab-CI](https://about.gitlab.com/product/continuous-integration/), [Travis CI](https://travis-ci.org/) and [CircleCI](https://circleci.com/)
 
 - [github](https://github.com/game-ci/unity3d-ci-example)
-- [gitlab](https://gitlab.com/gableroux/unity3d-gitlab-ci-example)
+- [gitlab](https://gitlab.com/game-ci/unity3d-gitlab-ci-example)
 
 ## How to run scripts locally
 
@@ -19,7 +19,7 @@ You can execute the local scripts and specify the path of your Unity executable 
 
 ## Test
 
-[`./local_test.sh`](https://gitlab.com/gableroux/unity3d-gitlab-ci-example/-/blob/master/local_test.sh)
+[`./local_test.sh`](https://gitlab.com/game-ci/unity3d-gitlab-ci-example/-/blob/main/local_test.sh)
 
 ```bash
 UNITY_EXECUTABLE="/Applications/Unity/Hub/Editor/2019.3.7f1/Unity.app/Contents/MacOS/Unity" \
@@ -28,7 +28,7 @@ UNITY_EXECUTABLE="/Applications/Unity/Hub/Editor/2019.3.7f1/Unity.app/Contents/M
 
 ## Build
 
-[`./local_build.sh`](https://gitlab.com/gableroux/unity3d-gitlab-ci-example/-/blob/master/local_build.sh)
+[`./local_build.sh`](https://gitlab.com/game-ci/unity3d-gitlab-ci-example/-/blob/main/local_build.sh)
 
 ```bash
 UNITY_EXECUTABLE="/Applications/Unity/Hub/Editor/2019.3.7f1/Unity.app/Contents/MacOS/Unity" \

--- a/docs/gitlab/03-example-project.md
+++ b/docs/gitlab/03-example-project.md
@@ -4,7 +4,7 @@
 
 [The `unity3d-gitlab-ci-example` project](https://gitlab.com/game-ci/unity3d-gitlab-ci-example/) uses an updated version of the [Unity's Creator Kit: RPG free asset](https://assetstore.unity.com/packages/templates/tutorials/creator-kit-rpg-149309) which is not affiliated with this project at all. Feel free to explore it, dialogs are a bit different ;)
 
-The example project is a Proof of Concept to **run unity3d tests and builds inside a CI** using **[game-ci/docker unity editor docker images](https://github.com/game-ci/docker)**. It currently creates builds for Windows, Linux, MacOS, webgl, Linux IL2cpp, Android and iOS Xcode project. The webgl build is published by the CI to [gitlab-pages](https://about.gitlab.com/features/pages/). **You can try the built project on [the published gitlab-pages](https://gableroux.gitlab.io/unity3d-gitlab-ci-example/)**.
+The example project is a Proof of Concept to **run unity3d tests and builds inside a CI** using **[game-ci/docker unity editor docker images](https://github.com/game-ci/docker)**. It currently creates builds for Windows, Linux, macOS, webgl, Linux IL2cpp, Android and iOS Xcode project. The webgl build is published by the CI to [gitlab-pages](https://about.gitlab.com/features/pages/). **You can try the built project on [the published gitlab-pages](https://game-ci.gitlab.io/unity3d-gitlab-ci-example/)**.
 
 ## Git remotes
 
@@ -15,7 +15,7 @@ The example project is a Proof of Concept to **run unity3d tests and builds insi
 
 ## How to run scripts locally
 
-You can execute the local scripts and specify the path of your Unity executable using `UNITY_EXECUTABLE`. You may try this in your project before you setup the whole CI so you confirm it works with your current unity version 👍.
+You can execute the local scripts and specify the path of your Unity executable using `UNITY_EXECUTABLE`. You may try this in your project before you setup the whole CI, so you confirm it works with your current unity version 👍.
 
 ## Test
 

--- a/docs/gitlab/custom-build-options.md
+++ b/docs/gitlab/custom-build-options.md
@@ -4,7 +4,7 @@ First, you need to understand how build options are passed to the build.
 
 ## Build command
 
-See [Assets/Scripts/Editor/BuildCommand.cs](https://gitlab.com/gableroux/unity3d-gitlab-ci-example/-/blob/master/Assets/Scripts/Editor/BuildCommand.cs).
+See [Assets/Scripts/Editor/BuildCommand.cs](https://gitlab.com/game-ci/unity3d-gitlab-ci-example/-/blob/main/Assets/Scripts/Editor/BuildCommand.cs).
 
 This is the script used during `Unity` command line execution. It is passed to the [`-executeMethod <ClassName.MethodName>` command line parameter](https://docs.unity3d.com/Manual/CommandLineArguments.html) like this:
 
@@ -19,7 +19,7 @@ You need to have this file in your project in order to build your project in the
 
 ### Workflow file
 
-See [.gitlab-ci.yml](https://gitlab.com/gableroux/unity3d-gitlab-ci-example/-/blob/master/.gitlab-ci.yml).
+See [.gitlab-ci.yml](https://gitlab.com/game-ci/unity3d-gitlab-ci-example/-/blob/main/.gitlab-ci.yml).
 
 You can add `BuildOptions` per target by adding environment variable `BuildOptions`.
 

--- a/docs/gitlab/deployment/android.md
+++ b/docs/gitlab/deployment/android.md
@@ -1,6 +1,6 @@
 # Android
 
-Before `2018.4.8f1` for 2018 versions and before `2019.2.4f1` for 2019 versions, you will need a specific Unity license (because that is not the same docker image). Add the content of your specific Unity license in your CI's environment variable : `UNITY_LICENSE_CONTENT_ANDROID`. _This is not required anymore now that images share a base image [See related change](https://gitlab.com/gableroux/unity3d/merge_requests/63)_
+Before `2018.4.8f1` for 2018 versions and before `2019.2.4f1` for 2019 versions, you will need a specific Unity license (because that is not the same docker image). Add the content of your specific Unity license in your CI's environment variable : `UNITY_LICENSE_CONTENT_ANDROID`. _This is not required anymore now that images share a base image [See related change](https://gitlab.com/game-ci/unity3d/merge_requests/63)_
 
 By default the apk is not signed and the build will use the Unity's default debug key.
 For _security reasons_, **you should not add your keystore to git**.
@@ -27,7 +27,7 @@ Note about _keystore security_, if you would like to use another solution for st
 
 `BUILD_APP_BUNDLE` env var is defined in `gitlab-ci.yml`. Set it to `true` to build an `.aab` file. Note: to build an android app bundle, you need an image with **Android NDK**.
 
-See [related issue gableroux/unity3d#61](https://gitlab.com/gableroux/unity3d/issues/61)
+See [related issue gableroux/unity3d#61](https://gitlab.com/game-ci/unity3d/issues/61)
 
 ### Bundle version code
 

--- a/docs/gitlab/tests.md
+++ b/docs/gitlab/tests.md
@@ -9,8 +9,8 @@ Unity supports two kinds of tests (`editmode` and `playmode`). The example proje
 
 Tests can be found here:
 
-- [`editmode` tests in `Assets/Scripts/Editor/EditModeTests`](https://gitlab.com/gableroux/unity3d-gitlab-ci-example/-/blob/master/Assets/Scripts/Editor/EditModeTests)
-- [`playmode` tests in `Assets/Tests/`](https://gitlab.com/gableroux/unity3d-gitlab-ci-example/-/blob/master/Assets/Tests/)
+- [`editmode` tests in `Assets/Scripts/Editor/EditModeTests`](https://gitlab.com/game-ci/unity3d-gitlab-ci-example/-/blob/main/Assets/Scripts/Editor/EditModeTests)
+- [`playmode` tests in `Assets/Tests/`](https://gitlab.com/game-ci/unity3d-gitlab-ci-example/-/blob/main/Assets/Tests/)
 
 ## Code coverage support
 

--- a/docs/troubleshooting/common-issues.md
+++ b/docs/troubleshooting/common-issues.md
@@ -67,4 +67,4 @@ iconv -f UTF-8 -t utf-16BE Unity_${version}.alf > Unity_${version}.utf16be.alf
 
 If you are using google account you can have some issue with activating unity. You just need to go on the unity website, settings, security and change your password. Then use your google email and your new password and it will work just fine ;)
 
-[Source](https://gitlab.com/gableroux/unity3d-gitlab-ci-example/-/issues/149)
+[Source](https://gitlab.com/game-ci/unity3d-gitlab-ci-example/-/issues/149)


### PR DESCRIPTION
#### Changes

* I moved `unity3d-gitlab-ci-example` project to [gitlab GameCI organization](https://gitlab.com/game-ci)
	* https://gitlab.com/game-ci/unity3d-gitlab-ci-example
* I moved `unity3d` legacy docker images project to [gitlab GameCI organization](https://gitlab.com/game-ci)
    * https://gitlab.com/game-ci/unity3d
* I archived `unity3d` legacy docker images project
* I updated `default` branch from `master` to `main` on `unity3d-gitlab-ci-example`.
