### PR TITLE
Clarify in iOS deploy docs that gym is an alias to build_app

### DIFF
--- a/docs/github/v2/15-deployment/ios.md
+++ b/docs/github/v2/15-deployment/ios.md
@@ -143,7 +143,7 @@ platform :ios do
       profile_uuid: ENV["sigh_#{ENV['IOS_BUNDLE_ID']}_appstore"]
     )
 
-    build_app(
+    build_app( #alias: gym
       project: "#{ENV['IOS_BUILD_PATH']}/iOS/Unity-iPhone.xcodeproj",
       scheme: 'Unity-iPhone',
       xcargs: '-allowProvisioningUpdates'
@@ -165,10 +165,10 @@ end
 
 This will install pods and generate the `xcworkspace` for you.
 
-Then change the `build_app` step at the end of this build phase to use the new `xcworkspace` instead of the old `xcodeproj`:
+Then change the [`build_app`](http://docs.fastlane.tools/actions/build_app/#build_app) (alias: [`gym`](https://docs.fastlane.tools/actions/gym/)) step at the end of this build phase to use the new `xcworkspace` instead of the old `xcodeproj`:
 
 ```ruby
-    build_app(
+    build_app( #alias: gym
       workspace: "#{ENV['IOS_BUILD_PATH']}/iOS/Unity-iPhone.xcworkspace",
       scheme: 'Unity-iPhone',
       xcargs: '-allowProvisioningUpdates'


### PR DESCRIPTION
Since users of gameci may not be familiar with fastlane and fastfiles, we clarify that `gym` is equivalent to `build_app` in case they are using a preexisting fastfile.

#### Changes

- ...

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../blob/main/CONTRIBUTING.md) and accept the [code](../blob/main/CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
