### PR TITLE
Revamp Android deployment docs

### DIFF
--- a/docs/github/v2/15-deployment/android.md
+++ b/docs/github/v2/15-deployment/android.md
@@ -34,7 +34,7 @@ Follow the ["Setup" section of the Fastlane Supply documentation](https://docs.f
 
 After the last step, it will tell you to test the connection to the Google Play Store, and then add your JSON file path to your Appfile. You can do the first step if you would like (you may need to run `bundle exec fastlane` instead of just `fastlane`), but don't worry about the Appfile, as we will be be creating that in the next step.
 
-Instead, create a Repository Secret in your GitHub repository by going to Settings -> Secrets and clicking the "New repository secret" button in the top-right. It should be titled `GOOGLE_PLAY_KEY_FILE` and its value should be the plaintext contents of the download JSON file.
+Instead, create a Repository Secret in your GitHub repository by going to Settings -> Secrets and clicking the "New repository secret" button in the top-right. It should be titled `GOOGLE_PLAY_KEY_FILE` and its value should be the plaintext contents of the downloaded JSON file.
 
 ### 3- Generate an upload key and keystore
 

--- a/docs/github/v2/15-deployment/android.md
+++ b/docs/github/v2/15-deployment/android.md
@@ -40,8 +40,7 @@ Instead, create a Repository Secret in your GitHub repository by going to Settin
 
 Distributing an app via the Google Play store requires uploading an unsigned Android App Bundle (AAB) file and letting Google codesign your app for you using Play App Signing. In order to do this, you need to create an upload signing key, which you will then sign your app with.
 
-In Unity, while Android is your selected build platform, open Player Settings.
-TODO: Write up Unity instructions. Under "Publishing Settings", click the "Keystore Manager" button to open the keystore manager. Click the "Keystore" dropdown, and then "Create New" > "Anywhere" to create a new keystore file. You can select any file location, just note where it is.
+In Unity, while Android is your selected build platform, open Player Settings. Under "Publishing Settings", click the "Keystore Manager" button to open the keystore manager. Click the "Keystore" dropdown, and then "Create New" > "Anywhere" to create a new keystore file. You can select any file location, just note where it is.
 
 Fill out all the fields in this form. Both of the password and password confirmation fields (so, four password fields total) should contain the same password. Click "Add key" when you're done. In Player Settings, confirm that the "Custom Keystore" checkbox is checked, and the correct keystore path, keystore password, alias name, and alias password are set. Be sure to commit and push these changes to your git repository.
 
@@ -59,7 +58,7 @@ Add four Repository Secrets in your GitHub repository by going to Settings -> Se
 
 In order to automate submission to the Google Play store, Google requires you to have already manually uploaded a version of your app to the Google Play Console. You also need to get your app out of the "Draft" status if you want to deploy anything but draft releases.
 
-To begin, build your game in Unity. Ensure that the "TODO" checkbox is checked in the TODO settings, and that the keystore from the previous step is selected in the Publishing Settings section of the Player Settings. If both of these are correct, your build should produce an `.aab` file that has been signed with your upload key.
+To begin, build your game in Unity. Ensure that the "Build App Bundle (Google Play)" checkbox is checked in the Build Settings, and that the keystore from the previous step is selected in the Publishing Settings section of the Player Settings. If both of these are correct, your build should produce an `.aab` file that has been signed with your upload key.
 
 In the Google Play Console, select "Internal Testing" from the left-side menu (or an alternate track if you want to do a public production or beta released). Click "Create new release", and drag in an AAB you've manually built in Unity (or an existing GitHub Actions workflow). Fill out the rest of the required fields, then click Save.
 
@@ -165,7 +164,7 @@ jobs:
 
 On your project's GitHub repo page, add a number of Repository Secrets by going to Settings -> Secrets and clicking the "New repository secret" button in the top-right.
 
-- **ANDROID_KEYSTORE_BASE64** : Base64 of your keystore in step 2
+- **ANDROID_KEYSTORE_BASE64** : Base64 of your keystore, generated in step 3
 - **ANDROID_KEYSTORE_PASS**: Password for your keystore
 - **ANDROID_KEYALIAS_NAME**: Name of the alias in your keystore
 - **ANDROID_KEYALIAS_PASS**: Password for the alias in your keystore

--- a/docs/github/v2/15-deployment/android.md
+++ b/docs/github/v2/15-deployment/android.md
@@ -1,9 +1,20 @@
 # Deploy to Google Play
 
-### 1- Install fastlane
+This guide is intended to help with automating Android builds to upload to the Play Store. If you are planning to use an alternate distribution method, such as a third-party beta test service or manually sideloading an APK, you do not need this guide. Setting up the [unity-builder](https://game.ci/docs/github/builder) action with a `targetPlatform` of `Android` should produce a functioning APK. However, if you are intending to distribute your game on the Play Store, either for public distribution or a beta track, this guide is for you.
 
-The recommended approach to install [fastlane](https://docs.fastlane.tools/getting-started/android/setup/)
-is to make a `Gemfile` with following content:
+### 1- Install Fastlane
+
+[Fastlane](https://docs.fastlane.tools/getting-started/ios/setup/) is a tool that can facilitate building and submitting your Android apps to Google, and is the easiest way to deploy your Unity project to Android for Play Store distribution.
+
+To configure Fastlane for your GitHub Actions workflow runners, you will need to locally set up a `Gemfile` and `Fastfile` within your project. A `Gemfile` specifies what Ruby dependencies are needed to set up and run Fastlane (which is written in Ruby), and a `Fastfile` will be how you configure your iOS build settings. We will set up the `Gemfile` now, and the `Fastfile` in a later step.
+
+You will need your local machine to have [Ruby](https://www.ruby-lang.org/en/documentation/installation/) installed, as well as Bundler. If you have Ruby installed but are unsure if you have Bundler, you can run the following to install it:
+
+```bash
+gem install bundler
+```
+
+From there, create a file called `Gemfile` in the root of your git repository with following content:
 
 ```ruby
 # Gemfile
@@ -11,22 +22,52 @@ source "https://rubygems.org"
 gem "fastlane"
 ```
 
-Then run `bundle install` to create the `Gemfile.lock`
+Then run `bundle install`. This will create an additional `Gemfile.lock` file in the root of your project.
 
-Upload both `Gemfile` and `Gemfile.lock` to your repo.
+Commit both `Gemfile` and `Gemfile.lock` to your repo.
 
-### 2- Prepare Google Play
+### 2- Create a Google Play Service Account
 
-You need to manually upload your **first** version of your application to Google Play. You also need to get your app out of the "draft" status if you want to deploy anything but draft releases. The easiest way to do this is to try to release an Alpha release manually through play console. You will be guided to answer all the right forms.
+To programmatically access the Google Play Console, you will need a dedicated Google Play service account with API access.
 
-The output should be signed using a signing key. This can be done by creating the signing key from
-[Unity/Player Settings/Publishing Settings](https://docs.unity3d.com/2017.3/Documentation/Manual/class-PlayerSettingsAndroid.html) .
+Follow the ["Setup" section of the Fastlane Supply documentation](https://docs.fastlane.tools/actions/supply/) to create a service account.
 
-- Follow the setup steps from [these fastlane docs](https://docs.fastlane.tools/actions/supply/) to create a service account.
+After the last step, it will tell you to test the connection to the Google Play Store, and then add your JSON file path to your Appfile. You can do the first step if you would like (you may need to run `bundle exec fastlane` instead of just `fastlane`), but don't worry about the Appfile, as we will be be creating that in the next step.
 
-> -- **Note:** Keep your keystore and service_account.json file somewhere safe. You will need them later to upload new releases.
+Instead, create a Repository Secret in your GitHub repository by going to Settings -> Secrets and clicking the "New repository secret" button in the top-right. It should be titled `GOOGLE_PLAY_KEY_FILE` and its value should be the plaintext contents of the download JSON file.
 
-### 3- Add the following fastlane files to your fastlane folder
+### 3- Generate an upload key and keystore
+
+Distributing an app via the Google Play store requires uploading an unsigned Android App Bundle (AAB) file and letting Google codesign your app for you using Play App Signing. In order to do this, you need to create an upload signing key, which you will then sign your app with.
+
+In Unity, while Android is your selected build platform, open Player Settings.
+TODO: Write up Unity instructions. Under "Publishing Settings", click the "Keystore Manager" button to open the keystore manager. Click the "Keystore" dropdown, and then "Create New" > "Anywhere" to create a new keystore file. You can select any file location, just note where it is.
+
+Fill out all the fields in this form. Both of the password and password confirmation fields (so, four password fields total) should contain the same password. Click "Add key" when you're done. In Player Settings, confirm that the "Custom Keystore" checkbox is checked, and the correct keystore path, keystore password, alias name, and alias password are set. Be sure to commit and push these changes to your git repository.
+
+If you would rather use Android Studio to generate an upload key and keystore, you can follow [Google's guide](https://developer.android.com/studio/publish/app-signing#generate-key) and then manually select that keystore within the Unity Player Settings. It doesn't matter as long as you end up with a valid `.keystore` file and Unity is configured to use that custom keystore.
+
+Be sure to keep your `.keystore` file and password handy, as we will be using them in future steps. We recommend that you **not** check your `.keystore` file into git, as this can reduce security. If your workflow requires developers to be able to manually build the project, we recommend adding the `.keystore` file to your `.gitignore` (if you want to keep it in your project directory) and finding an alternate way to transfer it between developers, such as a shared password manager that supports file uploads.
+
+Next, you will need to add the keystore information to your GitHub repository.
+
+Begin by base64-encoding the contents of your `.keystore` file. On a Linux or MacOS command-line prompt, you can use the `base64` command to do so: `base64 user.keystore` (assuming you're in the correct working directory and your keystore file is named `user.keystore`). In Windows PowerShell, the following command will generate the same results: `[convert]::ToBase64String((Get-Content -path "user.keystore" -Encoding byte))`
+
+Add four Repository Secrets in your GitHub repository by going to Settings -> Secrets and clicking the "New repository secret" button in the top-right. `ANDROID_KEYSTORE_BASE64` should contain the base64'd version of your keystore file's contents, and `ANDROID_KEYSTORE_PASS`, `ANDROID_KEYALIAS_NAME`, and `ANDROID_KEYALIAS_PASS` should contain your keystore's password, alias name, and alias password respectively. If you followed the instructions above, the keystore password and alias password will be the same.
+
+### 4- Manually upload a build to Google Play
+
+In order to automate submission to the Google Play store, Google requires you to have already manually uploaded a version of your app to the Google Play Console. You also need to get your app out of the "Draft" status if you want to deploy anything but draft releases.
+
+To begin, build your game in Unity. Ensure that the "TODO" checkbox is checked in the TODO settings, and that the keystore from the previous step is selected in the Publishing Settings section of the Player Settings. If both of these are correct, your build should produce an `.aab` file that has been signed with your upload key.
+
+In the Google Play Console, select "Internal Testing" from the left-side menu (or an alternate track if you want to do a public production or beta released). Click "Create new release", and drag in an AAB you've manually built in Unity (or an existing GitHub Actions workflow). Fill out the rest of the required fields, then click Save.
+
+Before you can programmatically deploy any release that is not a "Draft" release, you'll need to manually submit your app for review at least once to get it out of "Draft" status. Depending on where you are in the game production lifecycle, you may not want to this during initial setup, but be aware this is something you will need to do before you can use GameCI to release new live updates to a production build.
+
+### 5- Set up Fastlane
+
+At this point, your Google Play Console app listing should be ready to accept programmatic uploads, but you still need to configure Fastlane. Within your project directory, create a directory called `fastlane`, and then create two files within that directory, `Appfile` and `Fastfile`.
 
 ```ruby
 # fastlane/Appfile
@@ -39,17 +80,25 @@ end
 ```ruby
 # fastlane/Fastfile
 platform :android do
-  desc "Upload a new Android version to the Google Play Store"
-  lane :internal do
-    upload_to_play_store(track: 'internal',release_status: 'completed',aab: "#{ENV['ANDROID_BUILD_FILE_PATH']}")
+  desc "Upload a new Android version to the production Google Play Store"
+  lane :production do
+    upload_to_play_store(track: 'production', release_status: 'completed', aab: "#{ENV['ANDROID_BUILD_FILE_PATH']}")
   end
-  lane :alpha do
-    upload_to_play_store(track: 'alpha',release_status: 'completed',aab: "#{ENV['ANDROID_BUILD_FILE_PATH']}")
+
+  desc "Upload a new Android internal version to Google Play"
+  lane :internal do
+    upload_to_play_store(track: 'internal', release_status: 'completed', aab: "#{ENV['ANDROID_BUILD_FILE_PATH']}")
   end
 end
 ```
 
-### 4- Add jobs to your GitHub workflow
+If you would like to upload to other tracks (namely, `alpha` or `beta`), you can create additional lanes that look the same as the `:production` and `:internal` lanes except for the name and `track` parameter. Additionally, if you want to create draft releases (which will be necessary until you've manually pushed at least one build through the manual submission process), you will want to switch `release_status` from `completed` to `draft`.
+
+### 6- Add jobs to your GitHub workflow
+
+The following workflow establishes two jobs. The first builds your game into an AAB file, and the second uploads that generated bundle to the Play Store.
+
+If you instead intend to manually distribute your game outside the Play Store as an APK, remove the `androidAppBundle` flag from the `with` section of the `game-ci/unity-builder@v2` action in the workflow. You can also remove the `androidKeystoreName`, `androidKeystoreBase64`, `androidKeyStorePass`, `androidKeyaliasName`, and `androidKeyaliasPass` properties. From there, you'll want to remove the entire `releaseToGooglePlay` job. If you just want to download the APK, it will be available in the "artifacts" section of a completed workflow run, or you can add a new job that performs whatever custom upload logic you'd like.
 
 ```yaml
 # .github/workflows/main.yml
@@ -67,7 +116,7 @@ jobs:
         with:
           targetPlatform: Android
           androidAppBundle: true
-          androidKeystoreName: user.keystore
+          androidKeystoreName: user # This file won't exist, but this property needs to exist.
           androidKeystoreBase64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
           androidKeystorePass: ${{ secrets.ANDROID_KEYSTORE_PASS }}
           androidKeyaliasName: ${{ secrets.ANDROID_KEYALIAS_NAME }}
@@ -96,7 +145,7 @@ jobs:
           path: build/Android
       - name: Add Authentication
         run: echo "$GOOGLE_PLAY_KEY_FILE" > $GOOGLE_PLAY_KEY_FILE_PATH
-      - name: Install Fastlane
+      - name: Set up Fastlane
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7.2
@@ -104,12 +153,7 @@ jobs:
       - name: Upload to Google Play Internal
         uses: maierj/fastlane-action@v2.0.1
         with:
-          lane: 'android internal'
-      # Uncomment to upload to alpha branch
-      #    - name: Upload to Google Play Alpha
-      #      uses: maierj/fastlane-action@v2.0.1
-      #      with:
-      #        lane: 'android alpha'
+          lane: 'android internal' # Change to upload to a different lane
       - name: Cleanup to avoid storage limit
         if: always()
         uses: geekyeggo/delete-artifact@v1
@@ -119,9 +163,13 @@ jobs:
 
 ### 5- Add secrets to your Github repo
 
-- **ANDROID_KEYSTORE_BASE64** : Base64 of your keystore in step 2. It is recommended to use bash's `base64` tool instead of an online base64 encoder for this.
+On your project's GitHub repo page, add a number of Repository Secrets by going to Settings -> Secrets and clicking the "New repository secret" button in the top-right.
+
+- **ANDROID_KEYSTORE_BASE64** : Base64 of your keystore in step 2
 - **ANDROID_KEYSTORE_PASS**: Password for your keystore
 - **ANDROID_KEYALIAS_NAME**: Name of the alias in your keystore
 - **ANDROID_KEYALIAS_PASS**: Password for the alias in your keystore
-- **GOOGLE_PLAY_KEY_FILE**: Your google account service .json file downloaded from step 2
-- **ANDROID_PACKAGE_NAME**: Your application package name e.g com.company.application
+- **GOOGLE_PLAY_KEY_FILE**: The contents of the Google Account Service .json file from step 2
+- **ANDROID_PACKAGE_NAME**: Your application package name (e.g com.company.application)
+
+If you get build failures around the keystore being invalid, _please_ confirm that your keystore base64, alias, and two passwords are correct, as that is a common source of failure. If you want to double-check your keystore has been correctly encoded as valid base64, you can locally recreate your keystore by manually running `cat [keystore file] | base64 --decode > user.keystore`, swapping in the name of a text file containing the base64 value. This will create a new keystore that you can attempt to manually build from in Unity. On Windows, this would be `[Text.Encoding]::Utf8.GetString([Convert]::FromBase64String('base 64 value')) | Out-File -FilePath .\user.keystore`

--- a/docs/github/v2/15-deployment/android.md
+++ b/docs/github/v2/15-deployment/android.md
@@ -1,6 +1,6 @@
 # Deploy to Google Play
 
-This guide is intended to help with automating Android builds to upload to the Play Store. If you are planning to use an alternate distribution method, such as a third-party beta test service or manually sideloading an APK, you do not need this guide. Setting up the [unity-builder](https://game.ci/docs/github/builder) action with a `targetPlatform` of `Android` should produce a functioning APK. However, if you are intending to distribute your game on the Play Store, either for public distribution or a beta track, this guide is for you.
+This guide is intended to help with automating Android builds to upload to the Play Store. If you just need to produce an APK, the [unity-builder](https://game.ci/docs/github/builder) action will do that. However, if you intend to distribute your game on the Play Store, either for public distribution or a beta track, this guide is for you.
 
 ### 1- Install Fastlane
 
@@ -96,8 +96,6 @@ If you would like to upload to other tracks (namely, `alpha` or `beta`), you can
 ### 6- Add jobs to your GitHub workflow
 
 The following workflow establishes two jobs. The first builds your game into an AAB file, and the second uploads that generated bundle to the Play Store.
-
-If you instead intend to manually distribute your game outside the Play Store as an APK, remove the `androidAppBundle` flag from the `with` section of the `game-ci/unity-builder@v2` action in the workflow. You can also remove the `androidKeystoreName`, `androidKeystoreBase64`, `androidKeyStorePass`, `androidKeyaliasName`, and `androidKeyaliasPass` properties. From there, you'll want to remove the entire `releaseToGooglePlay` job. If you just want to download the APK, it will be available in the "artifacts" section of a completed workflow run, or you can add a new job that performs whatever custom upload logic you'd like.
 
 ```yaml
 # .github/workflows/main.yml

--- a/docs/github/v2/15-deployment/android.md
+++ b/docs/github/v2/15-deployment/android.md
@@ -6,7 +6,7 @@ This guide is intended to help with automating Android builds to upload to the P
 
 [Fastlane](https://docs.fastlane.tools/getting-started/ios/setup/) is a tool that can facilitate building and submitting your Android apps to Google, and is the easiest way to deploy your Unity project to Android for Play Store distribution.
 
-To configure Fastlane for your GitHub Actions workflow runners, you will need to locally set up a `Gemfile` and `Fastfile` within your project. A `Gemfile` specifies what Ruby dependencies are needed to set up and run Fastlane (which is written in Ruby), and a `Fastfile` will be how you configure your iOS build settings. We will set up the `Gemfile` now, and the `Fastfile` in a later step.
+To configure Fastlane for your GitHub Actions workflow runners, you will need to locally set up a `Gemfile` and `Fastfile` within your project. A `Gemfile` specifies what Ruby dependencies are needed to set up and run Fastlane (which is written in Ruby), and a `Fastfile` will be how you configure your Android deployment settings. We will set up the `Gemfile` now, and the `Fastfile` in a later step.
 
 You will need your local machine to have [Ruby](https://www.ruby-lang.org/en/documentation/installation/) installed, as well as Bundler. If you have Ruby installed but are unsure if you have Bundler, you can run the following to install it:
 


### PR DESCRIPTION
#### Changes
  
This revamps the Android GitHub Actions deployment docs to be more in-depth and to not assume familiarity with Fastlane or Play Store deployment, in line with the new iOS deployment docs.

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../blob/main/CONTRIBUTING.md) and accept the [code](../blob/main/CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
