### PR TITLE
Added Code Coverage Documentation for GitHub Actions

### DIFF
--- a/docs/03-github/03-test-runner.mdx
+++ b/docs/03-github/03-test-runner.mdx
@@ -4,6 +4,9 @@ Running your test suite in an automated workflow helps increase certainty when m
 
 Use [Unity - Test runner](https://github.com/marketplace/actions/unity-test-runner) to run your Unity tests.
 
+_Optional_ to include test coverage, use
+[Unity Code Coverage](https://docs.unity3d.com/Packages/com.unity.testtools.codecoverage@1.2/manual/index.html)
+
 ## Basic setup
 
 By default, the test runner will run both `playmode` and `editmode` tests.
@@ -103,6 +106,24 @@ You can specify a different `artifactsPath` in the test runner and reference thi
     path: ${{ steps.myTestStep.outputs.artifactsPath }}
 ```
 
+### Getting coverage results
+
+The results for the test code coverage are stored in the folder `CodeCoverage` and the path
+can be read by the step's `outputs.coveragePath`. These coverage options can be configured
+as part of the test and by default will create an XML and HTML web page reports.
+
+```yaml
+- uses: actions/upload-artifact@v2
+  if: always()
+  with:
+    name: Coverage results
+    path: ${{ steps.myTestStep.outputs.coveragePath }}
+```
+
+The coverage results will be generated for whatever tests were selected to run.
+If both `editmode` and `playmode` are selected, then the results will have the
+combined coverage of both test modes.
+
 ## Caching
 
 In order to make test runs (and builds) faster,
@@ -193,6 +214,18 @@ In this folder a folder will be created for every test mode.
 
 _**required:** `false`_
 _**default:** `artifacts`_
+
+### coverageOptions
+
+Options for configuring code coverage, this configures the `-coverageOptions`
+parameter described unity's CodeCoverage documentation:
+[Using Code Coverage in batchmode](https://docs.unity3d.com/Packages/com.unity.testtools.codecoverage@1.2/manual/CoverageBatchmode.html).
+
+By default, the coverage is configured to generate an HTML report with additional metrics.
+This should be fine for most projects, but the webpage report can be quite large for projects
+with hundreds or thousands of large files. to disable the webpage report, remove the `generateHtmlReport`
+option from the coverage options. It is also recommended to add path or assembly filters for
+larger projects to keep the size of the report smaller if possible.
 
 #### useHostNetwork
 

--- a/docs/03-github/03-test-runner.mdx
+++ b/docs/03-github/03-test-runner.mdx
@@ -228,6 +228,11 @@ By default, this parameter is configured to generate an HTML report with additio
 This should be fine for most projects, but the webpage report can be quite large for projects
 with hundreds or thousands of large files.
 
+You can add arguments for `assemblyFilters` to specify an assembly to filter files that results are generated for.
+This is commonly used to ignore test files or external libraries. See the 
+[Using Code Coverage in batchmode](https://docs.unity3d.com/Packages/com.unity.testtools.codecoverage@1.2/manual/CoverageBatchmode.html).
+For example, you can add the argument `assemblyFilters:+MyScripts` to only include files in the namespace `MyScripts`.
+
 _**required:** `false`_
 _**default:** `generateAdditionalMetrics;generateHtmlReport;generateBadgeReport`_
 
@@ -324,7 +329,7 @@ jobs:
           artifactsPath: ${{ matrix.testMode }}-artifacts
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           checkName: ${{ matrix.testMode }} Test Results
-          coverageOptions: 'generateAdditionalMetrics;generateHtmlReport;generateBadgeReport;assemblyFilters:+MyScripts'
+          coverageOptions: 'generateAdditionalMetrics;generateHtmlReport;generateBadgeReport'
       - uses: actions/upload-artifact@v2
         if: always()
         with:

--- a/docs/03-github/03-test-runner.mdx
+++ b/docs/03-github/03-test-runner.mdx
@@ -121,8 +121,11 @@ as part of the test and by default will create an XML and HTML web page reports.
 ```
 
 The coverage results will be generated for whatever tests were selected to run.
-If both `editmode` and `playmode` are selected, then the results will have the
-combined coverage of both test modes.
+If both `editmode` and `playmode` are selected by using `all`, then the results
+will have the combined coverage of both test modes.
+
+_Note_ Coverage results are generated with root permission so to move or edit
+the output in later steps you may need to use elevated permissions such as `sudo`.
 
 ## Caching
 

--- a/docs/03-github/03-test-runner.mdx
+++ b/docs/03-github/03-test-runner.mdx
@@ -221,11 +221,12 @@ Options for configuring code coverage, this configures the `-coverageOptions`
 parameter described unity's CodeCoverage documentation:
 [Using Code Coverage in batchmode](https://docs.unity3d.com/Packages/com.unity.testtools.codecoverage@1.2/manual/CoverageBatchmode.html).
 
-By default, the coverage is configured to generate an HTML report with additional metrics.
+By default, this parameter is configured to generate an HTML report with additional metrics.
 This should be fine for most projects, but the webpage report can be quite large for projects
-with hundreds or thousands of large files. to disable the webpage report, remove the `generateHtmlReport`
-option from the coverage options. It is also recommended to add path or assembly filters for
-larger projects to keep the size of the report smaller if possible.
+with hundreds or thousands of large files.
+
+_**required:** `false`_
+_**default:** `generateAdditionalMetrics;generateHtmlReport;generateBadgeReport`_
 
 #### useHostNetwork
 
@@ -320,9 +321,15 @@ jobs:
           artifactsPath: ${{ matrix.testMode }}-artifacts
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           checkName: ${{ matrix.testMode }} Test Results
+          coverageOptions: 'generateAdditionalMetrics;generateHtmlReport;generateBadgeReport;assemblyFilters:+MyScripts'
       - uses: actions/upload-artifact@v2
         if: always()
         with:
           name: Test results for ${{ matrix.testMode }}
           path: ${{ steps.tests.outputs.artifactsPath }}
+      - uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: Coverage results for ${{ matrix.testMode }}
+          path: ${{ steps.tests.outputs.coveragePath }}
 ```

--- a/docs/03-github/03-test-runner.mdx
+++ b/docs/03-github/03-test-runner.mdx
@@ -5,7 +5,7 @@ Running your test suite in an automated workflow helps increase certainty when m
 Use [Unity - Test runner](https://github.com/marketplace/actions/unity-test-runner) to run your Unity tests.
 
 _Optional_ to include test coverage, use
-[Unity Code Coverage](https://docs.unity3d.com/Packages/com.unity.testtools.codecoverage@1.2/manual/index.html)
+[Unity - Code Coverage](https://docs.unity3d.com/Packages/com.unity.testtools.codecoverage@1.2/manual/index.html)
 
 ## Basic setup
 

--- a/docs/03-github/03-test-runner.mdx
+++ b/docs/03-github/03-test-runner.mdx
@@ -229,7 +229,7 @@ This should be fine for most projects, but the webpage report can be quite large
 with hundreds or thousands of large files.
 
 You can add arguments for `assemblyFilters` to specify an assembly to filter files that results are generated for.
-This is commonly used to ignore test files or external libraries. See the 
+This is commonly used to ignore test files or external libraries. See the
 [Using Code Coverage in batchmode](https://docs.unity3d.com/Packages/com.unity.testtools.codecoverage@1.2/manual/CoverageBatchmode.html).
 For example, you can add the argument `assemblyFilters:+MyScripts` to only include files in the namespace `MyScripts`.
 
@@ -329,7 +329,6 @@ jobs:
           artifactsPath: ${{ matrix.testMode }}-artifacts
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           checkName: ${{ matrix.testMode }} Test Results
-          coverageOptions: 'generateAdditionalMetrics;generateHtmlReport;generateBadgeReport'
       - uses: actions/upload-artifact@v2
         if: always()
         with:

--- a/docs/03-github/03-test-runner.mdx
+++ b/docs/03-github/03-test-runner.mdx
@@ -231,7 +231,10 @@ with hundreds or thousands of large files.
 You can add arguments for `assemblyFilters` to specify an assembly to filter files that results are generated for.
 This is commonly used to ignore test files or external libraries. See the
 [Using Code Coverage in batchmode](https://docs.unity3d.com/Packages/com.unity.testtools.codecoverage@1.2/manual/CoverageBatchmode.html).
-For example, you can add the argument `assemblyFilters:+MyScripts` to only include files in the namespace `MyScripts`.
+For example, you can add the argument `assemblyFilters:+my.assembly.*` to only include files in the assemblies that match `+my.assembly.*`,
+the `*` is a wildcard. This will require making an assembly definition to manage scripts, see Unity's documentation on
+[Assembly definitions](https://docs.unity3d.com/2022.2/Documentation/Manual/ScriptCompilationAssemblyDefinitionFiles.html)
+for how to create and manage assembly definitions.
 
 _**required:** `false`_
 _**default:** `generateAdditionalMetrics;generateHtmlReport;generateBadgeReport`_
@@ -329,6 +332,7 @@ jobs:
           artifactsPath: ${{ matrix.testMode }}-artifacts
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           checkName: ${{ matrix.testMode }} Test Results
+          coverageOptions: 'generateAdditionalMetrics;generateHtmlReport;generateBadgeReport;assemblyFilters:+my.assembly.*'
       - uses: actions/upload-artifact@v2
         if: always()
         with:


### PR DESCRIPTION
#### Changes

- Added basic documentation for github-actions test runner from changes part of release [v2.0.1](https://github.com/game-ci/unity-test-runner/releases/tag/v2.0.1) and PR https://github.com/game-ci/unity-test-runner/pull/182

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../blob/main/CONTRIBUTING.md) and accept the [code](../blob/main/CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
