### PR TITLE
Use v2 for unity-return-license

### DIFF
--- a/docs/github/v2/05-returning-a-license.md
+++ b/docs/github/v2/05-returning-a-license.md
@@ -15,6 +15,6 @@ Add this step to your workflow:
 ```yaml
 # Return License
 - name: Return license
-  uses: game-ci/unity-return-license@v1
+  uses: game-ci/unity-return-license@v2
   if: always()
 ```


### PR DESCRIPTION
#### Changes

- Use v2 for unity-return-license

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../blob/main/CONTRIBUTING.md) and accept the [code](../blob/main/CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
