### PR TITLE
Avoid needing escapes in bash

### DIFF
--- a/docs/gitlab/02-activation.md
+++ b/docs/gitlab/02-activation.md
@@ -54,7 +54,7 @@ All you need is [docker](https://www.docker.com/) installed on your machine.
    -logFile /dev/stdout \
    -batchmode \
    -nographics \
-   -username "$UNITY_USERNAME" -password "$UNITY_PASSWORD"
+   -username 'YOUR_UNITY_USERNAME' -password 'YOUR_UNITY_PASSWORD'
    ```
 
 4. Wait for output that looks like this:


### PR DESCRIPTION
#### Changes

- Use single quotes to make this call safe for passwords generated by Google Chrome's password generator

#### Checklist

- [x] Read the contribution [guide](../blob/main/CONTRIBUTING.md) and accept the [code](../blob/main/CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
