### PR TITLE
Docusaurus versions page as docs page

### DIFF
--- a/docs/03-docker/04-versions.mdx
+++ b/docs/03-docker/04-versions.mdx
@@ -1,7 +1,7 @@
+import VersionsPage from '@site/src/components/VersionsPage';
+
 # Available versions
 
 The following docker images are published by GameCI and are available for use in your pipelines.
-
-import VersionsPage from '@site/src/components/VersionsPage';
 
 <VersionsPage />

--- a/docs/03-docker/04-versions.mdx
+++ b/docs/03-docker/04-versions.mdx
@@ -1,0 +1,7 @@
+# Available versions
+
+The following docker images are published by GameCI and are available for use in your pipelines.
+
+import VersionsPage from '@site/src/components/VersionsPage';
+
+<VersionsPage />

--- a/docs/03-docker/versions.md
+++ b/docs/03-docker/versions.md
@@ -1,1 +1,0 @@
-[//]: # ( See src/pages/docs/docker/versions.tsx )

--- a/src/components/versionsPage.tsx
+++ b/src/components/versionsPage.tsx
@@ -1,6 +1,4 @@
 import React from 'react';
-import Layout from '@theme/Layout';
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Versions from "@site/src/components/docs/versions/versions";
 
 import 'firebase/auth';
@@ -24,7 +22,6 @@ function VersionsAntdWrapper() {
   const antdDarkTheme = "https://unpkg.com/antd/dist/antd.dark.css";
 
   const {isDarkTheme} = useColorMode();
-
 
   const addCssToHead = () => {
     const css = document.createElement('link');
@@ -54,20 +51,13 @@ function VersionsAntdWrapper() {
 }
 
 export default function VersionsPage(): JSX.Element {
-  const {siteConfig} = useDocusaurusContext();
   return (
     <Provider store={store}>
       <FirebaseAppProvider firebaseConfig={config.firebase}>
         <IconContext.Provider value={{ className: 'anticon' }}>
-          <Layout
-            title={`${siteConfig.title} - Docker images versions`}
-            description="Docker images versions">
-            <main>
-              <Section className={styles.versionsSection}>
-                <VersionsAntdWrapper />
-              </Section>
-            </main>
-          </Layout>
+          <div className={styles.versionsSection}>
+            <VersionsAntdWrapper />
+          </div>
         </IconContext.Provider>
       </FirebaseAppProvider>
     </Provider>

--- a/versioned_docs/version-1/03-docker/versions.md
+++ b/versioned_docs/version-1/03-docker/versions.md
@@ -1,1 +1,0 @@
-[//]: # ( See src/pages/docs/docker/versions.tsx )


### PR DESCRIPTION
Creating a draft to demonstrate versions page as a docs page instead of a docusaurus page. This will be a good solution once we get rid of antd, but for now, it breaks the ui a little too much.