### PR TITLE
Fixing Artifact download destination

### DIFF
--- a/docs/03-github/06-deployment/android.mdx
+++ b/docs/03-github/06-deployment/android.mdx
@@ -202,7 +202,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: build-Android
-          path: build/Android
+          path: build
       - name: Add Authentication
         run: echo "$GOOGLE_PLAY_KEY_FILE" > $GOOGLE_PLAY_KEY_FILE_PATH
       - name: Set up Fastlane


### PR DESCRIPTION
When downloading the artifact to a any folder the step recreates the same directory structure with which the artifacts where first uploaded.
For example, if you upload the `Android` folder with all its content and then download it in the next job inside the `build/Android` folder you'll endup with this structure
```
build
  Android
    Android
      ** // all files and folder inside the artfact root folder
```
This prevents the _Upload to Google Play Internal_ step from finding the .aab file since there is an extra unexpexted folder in under the target directory of that job.

#### Changes

Changing the location of `actions/download-artifact@v2` seems to solve the problem.

#### Checklist

- [x] Read the contribution [guide](../blob/main/CONTRIBUTING.md) and accept the
      [code](../blob/main/CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
