### PR TITLE
Fix 'welcome' footer link

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -193,7 +193,7 @@ const config = {
             items: [
               {
                 label: 'Welcome to GameCI',
-                to: '/docs/index',
+                to: '/docs/',
               },
               {
                 label: 'Getting Started with Github',


### PR DESCRIPTION
`/docs/index` was returning a 404, so pointed it at `/docs/`