### PR TITLE
Add sync_certificates lane to iOS deployment Fastfile

### DIFF
--- a/docs/03-github/06-deployment/ios.mdx
+++ b/docs/03-github/06-deployment/ios.mdx
@@ -299,7 +299,7 @@ platform :ios do
       type: "appstore",
       storage_mode: "git",
       git_url: "git@github.com:#{match_org}/#{match_repo}.git",
-      app_identifier: ENV["BUNDLE_ID"]
+      app_identifier: ENV["IOS_BUNDLE_ID"]
     )
   end
 

--- a/docs/03-github/06-deployment/ios.mdx
+++ b/docs/03-github/06-deployment/ios.mdx
@@ -291,7 +291,7 @@ platform :ios do
   lane :sync_certificates do
     app_store_connect_api_key(
       key_id: ENV["APPSTORE_KEY_ID"],
-      issuer_id: ENV["APP_STORE_CONNECT_ISSUER_ID"],
+      issuer_id: ENV["APPSTORE_ISSUER_ID"],
       key_content: ENV['APP_STORE_CONNECT_KEY']
     )
 

--- a/docs/03-github/06-deployment/ios.mdx
+++ b/docs/03-github/06-deployment/ios.mdx
@@ -287,6 +287,22 @@ platform :ios do
     )
   end
 
+  desc "Sync codesigning certificates"
+  lane :sync_certificates do
+    app_store_connect_api_key(
+      key_id: ENV["APP_STORE_CONNECT_KEY_ID"],
+      issuer_id: ENV["APP_STORE_CONNECT_ISSUER_ID"],
+      key_content: ENV['APP_STORE_CONNECT_KEY']
+    )
+
+    match(
+      type: "appstore",
+      storage_mode: "git",
+      git_url: "git@github.com:#{match_org}/#{match_repo}.git",
+      app_identifier: ENV["BUNDLE_ID"]
+    )
+  end
+
   desc "Deliver a new Release build to the App Store"
   lane :release do
     build

--- a/docs/03-github/06-deployment/ios.mdx
+++ b/docs/03-github/06-deployment/ios.mdx
@@ -292,7 +292,7 @@ platform :ios do
     app_store_connect_api_key(
       key_id: ENV["APPSTORE_KEY_ID"],
       issuer_id: ENV["APPSTORE_ISSUER_ID"],
-      key_content: ENV['APP_STORE_CONNECT_KEY']
+      key_content: ENV['APPSTORE_P8']
     )
 
     match(

--- a/docs/03-github/06-deployment/ios.mdx
+++ b/docs/03-github/06-deployment/ios.mdx
@@ -290,7 +290,7 @@ platform :ios do
   desc "Sync codesigning certificates"
   lane :sync_certificates do
     app_store_connect_api_key(
-      key_id: ENV["APP_STORE_CONNECT_KEY_ID"],
+      key_id: ENV["APPSTORE_KEY_ID"],
       issuer_id: ENV["APP_STORE_CONNECT_ISSUER_ID"],
       key_content: ENV['APP_STORE_CONNECT_KEY']
     )

--- a/docs/03-github/06-deployment/ios.mdx
+++ b/docs/03-github/06-deployment/ios.mdx
@@ -207,7 +207,7 @@ jobs:
         run: |
           eval "$(ssh-agent -s)"
           ssh-add - <<< "${MATCH_DEPLOY_KEY}"
-          bundle exec fastlane sync_certificates
+          bundle exec fastlane ios sync_certificates
         env:
           APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
           APP_STORE_CONNECT_KEY: ${{ secrets.APP_STORE_CONNECT_KEY }} # Raw .p8 value
@@ -397,10 +397,10 @@ an Xcode project, which then must be built and code-signed in Xcode via fastlane
 
 This workflow builds your app and submits it to Apple for App Store release. If you want to submit
 your app for TestFlight distribution, you can create a job that is identical except it runs
-`bundle exec fastlane beta` instead of `bundle exec fastlane release` during the "Fix File
+`bundle exec fastlane ios beta` instead of `bundle exec fastlane ios release` during the "Fix File
 Permissions and Run fastlane" step. You can build your iOS app without uploading it (e.g. to confirm
 it builds successfully, or as a preparation step before uploading to an alternative distribution
-service) by instead running `bundle exec fastlane build`.
+service) by instead running `bundle exec fastlane ios build`.
 
 Please note that Apple will aggressively rate-limit you if you try to upload builds too frequently.
 We recommend you configure any workflow that submits to the App Store or TestFlight to be manually


### PR DESCRIPTION
#### Changes

As per @davidmfinol in Discord, this adds the `sync_certificates` fastlane lane to the iOS deployment guide, which was referenced in the example workflow but not actually included in the example Fastfile. 

It also makes sure we’re consistently calling `bundle exec fastlane ios [command]` instead of just `bundle exec fastlane [command]`. The latter will work consistently on a Fastlane project with just iOS, but in a project with both iOS and Android it may fail depending on which platform has been set to the default. There’s no real downside to us being more verbose + precise.

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../blob/main/CONTRIBUTING.md) and accept the
      [code](../blob/main/CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)