### PR TITLE
Documentation improvements for android build and app store deployment

### DIFF
--- a/docs/03-github/04-builder.mdx
+++ b/docs/03-github/04-builder.mdx
@@ -288,7 +288,7 @@ Set this flag to `true` to build '.aab' instead of '.apk'.
     androidKeyaliasPass: ${{ secrets.ANDROID_KEYALIAS_PASS }}
 ```
 
-You should also set all the Android Keystore options (see below).
+You should also set all the Android Keystore options (see below). Refer to (this section)[/docs/github/deployment/android#3-generate-an-upload-key-and-keystore] for keystore setup.
 
 _**required:** `false`_ _**default:** `false`_
 

--- a/docs/03-github/04-builder.mdx
+++ b/docs/03-github/04-builder.mdx
@@ -288,7 +288,8 @@ Set this flag to `true` to build '.aab' instead of '.apk'.
     androidKeyaliasPass: ${{ secrets.ANDROID_KEYALIAS_PASS }}
 ```
 
-You should also set all the Android Keystore options (see below). Refer to (this section)[/docs/github/deployment/android#3-generate-an-upload-key-and-keystore] for keystore setup.
+You should also set all the Android Keystore options (see below). Refer to (this
+section)[/docs/github/deployment/android#3-generate-an-upload-key-and-keystore] for keystore setup.
 
 _**required:** `false`_ _**default:** `false`_
 

--- a/docs/03-github/06-deployment/ios.mdx
+++ b/docs/03-github/06-deployment/ios.mdx
@@ -64,6 +64,8 @@ project.
 
 Commit both `Gemfile` and `Gemfile.lock` to your repo.
 
+> -- **Note:** Depending on your local OS you might need to run `bundle lock --add-platform x86_64-linux` and `bundle lock --add-platform x86_64-darwin-19` commands in order to add the required platforms to `Gemfile.lock` file. Be sure to commit the `Gemfile.lock` after running these commands.
+
 ### 2. Generate an App Store Connect API Key
 
 In order for fastlane match to fetch and validate your codesigning certificates, it needs to
@@ -252,6 +254,8 @@ Go to the "Actions" tab in your GitHub repository, and manually run the "iOS One
 by selecting it from the list on the left, clicking the "Run Workflow" button, and then clicking the
 next "Run Workflow" button after confirming the branch is correct. This will run both of those two
 workflows, configuring your Match git repository and then generating certificates with Apple.
+
+> -- **Note:** If `Generate iOS Certs` causes an `Unknown platform` issue, go into the `Gemfile.lock` file and under `PLATFORMS` delete any lines that are not `x86_64-darwin-19` or `x86_64-linux`. Don't forget to commit and push the file before running the action again.
 
 ### 4b. Manage codesigning manually on your Mac
 
@@ -467,6 +471,8 @@ jobs:
           IOS_BUNDLE_ID: com.company.application # Change it to match your Unity bundle id
           PROJECT_NAME: Your Project Name # Change it to match your project's name
         run: |
+          eval "$(ssh-agent -s)"
+          ssh-add - <<< "${MATCH_DEPLOY_KEY}"
           find $IOS_BUILD_PATH -type f -name "**.sh" -exec chmod +x {} \;
           bundle install
           bundle exec fastlane ios release

--- a/docs/03-github/06-deployment/ios.mdx
+++ b/docs/03-github/06-deployment/ios.mdx
@@ -64,7 +64,10 @@ project.
 
 Commit both `Gemfile` and `Gemfile.lock` to your repo.
 
-> -- **Note:** Depending on your local OS you might need to run `bundle lock --add-platform x86_64-linux` and `bundle lock --add-platform x86_64-darwin-19` commands in order to add the required platforms to `Gemfile.lock` file. Be sure to commit the `Gemfile.lock` after running these commands.
+> -- **Note:** Depending on your local OS you might need to run
+> `bundle lock --add-platform x86_64-linux` and `bundle lock --add-platform x86_64-darwin-19`
+> commands in order to add the required platforms to `Gemfile.lock` file. Be sure to commit the
+> `Gemfile.lock` after running these commands.
 
 ### 2. Generate an App Store Connect API Key
 
@@ -255,7 +258,9 @@ by selecting it from the list on the left, clicking the "Run Workflow" button, a
 next "Run Workflow" button after confirming the branch is correct. This will run both of those two
 workflows, configuring your Match git repository and then generating certificates with Apple.
 
-> -- **Note:** If `Generate iOS Certs` causes an `Unknown platform` issue, go into the `Gemfile.lock` file and under `PLATFORMS` delete any lines that are not `x86_64-darwin-19` or `x86_64-linux`. Don't forget to commit and push the file before running the action again.
+> -- **Note:** If `Generate iOS Certs` causes an `Unknown platform` issue, go into the
+> `Gemfile.lock` file and under `PLATFORMS` delete any lines that are not `x86_64-darwin-19` or
+> `x86_64-linux`. Don't forget to commit and push the file before running the action again.
 
 ### 4b. Manage codesigning manually on your Mac
 


### PR DESCRIPTION
#### Changes

- Building android bundle(.aab) instructions are missing under Builder documentation, and exists in deployment to play store. Linked the relevant part in the Builder documentation.
- `bundle install` step sends a platform error when the `Gemfile.lock` is generated on an OS that differentiates from the OS the job uses, added the necessary lines to fix this error.
- iOS deployment job, as far as I could tell, had no steps that added ssh authorization to the private repository containing the app store certificates. Added 2 lines that fixed this issue.

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../blob/main/CONTRIBUTING.md) and accept the
      [code](../blob/main/CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
