### PR TITLE
feat: display an additional level in toc of test runner and builder docs

### DIFF
--- a/docs/03-github/03-test-runner.mdx
+++ b/docs/03-github/03-test-runner.mdx
@@ -1,3 +1,7 @@
+---
+toc_max_heading_level: 4
+---
+
 # Test runner
 
 Running your test suite in an automated workflow helps increase certainty when merging.

--- a/docs/03-github/04-builder.mdx
+++ b/docs/03-github/04-builder.mdx
@@ -1,3 +1,7 @@
+---
+toc_max_heading_level: 4
+---
+
 # Builder
 
 Building the project as part of a workflow may help to create mind-space and focus on the project
@@ -231,18 +235,17 @@ Find the available strategies below:
 
 Versioning out of the box! **(recommended)**
 
-> Compatible with **all platforms**.  
-> Does **not** modify your repository.  
-> Requires **zero configuration**.
+> Compatible with **all platforms**. Does **not** modify your repository. Requires **zero
+> configuration**.
 
 How it works:
 
-> Generates a version based on [semantic versioning](https://semver.org/).  
-> Follows `<major>.<minor>.<patch>` for example `0.17.2`.  
-> The latest tag dictates `<major>.<minor>` (defaults to 0.0 for no tag).  
-> The number of commits (since the last tag, if any) is used for `<patch>`.  
-> To increment major or minor version, manually add a tag to a commit that follows the `<major>.<minor>` versioning convention.  
-> Optionally, the version number can have a `v` prefix, for example `v0.17`.  
+> Generates a version based on [semantic versioning](https://semver.org/). Follows
+> `<major>.<minor>.<patch>` for example `0.17.2`. The latest tag dictates `<major>.<minor>`
+> (defaults to 0.0 for no tag). The number of commits (since the last tag, if any) is used for
+> `<patch>`. To increment major or minor version, manually add a tag to a commit that follows the
+> `<major>.<minor>` versioning convention. Optionally, the version number can have a `v` prefix, for
+> example `v0.17`.
 
 No configuration required.
 

--- a/versioned_docs/version-1/04-github/03-test-runner.mdx
+++ b/versioned_docs/version-1/04-github/03-test-runner.mdx
@@ -1,3 +1,7 @@
+---
+toc_max_heading_level: 4
+---
+
 # Test runner
 
 Running your test suite in an automated workflow helps increase certainty when merging.

--- a/versioned_docs/version-1/04-github/04-builder.mdx
+++ b/versioned_docs/version-1/04-github/04-builder.mdx
@@ -1,3 +1,7 @@
+---
+toc_max_heading_level: 4
+---
+
 # Builder
 
 Building the project as part of a workflow may help to create mind-space and focus on the project
@@ -172,16 +176,15 @@ Find the available strategies below:
 
 Versioning out of the box! **(recommended)**
 
-> Compatible with **all platforms**.  
-> Does **not** modify your repository.  
-> Requires **zero configuration**.
+> Compatible with **all platforms**. Does **not** modify your repository. Requires **zero
+> configuration**.
 
 How it works:
 
-> Generates a version based on [semantic versioning](https://semver.org/).  
-> Follows `<major>.<minor>.<patch>` for example `0.17.2`.  
-> The latest tag dictates `<major>.<minor>` (defaults to 0.0 for no tag).  
-> The number of commits (since the last tag, if any) is used for `<patch>`.
+> Generates a version based on [semantic versioning](https://semver.org/). Follows
+> `<major>.<minor>.<patch>` for example `0.17.2`. The latest tag dictates `<major>.<minor>`
+> (defaults to 0.0 for no tag). The number of commits (since the last tag, if any) is used for
+> `<patch>`.
 
 No configuration required.
 


### PR DESCRIPTION
#### Changes

- Adds an additional level in the table of contents for unity-builder and test runner

![image](https://user-images.githubusercontent.com/20756439/182965613-aade7f03-68e2-45b8-a14c-c6687301f6b6.png)


#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../blob/main/CONTRIBUTING.md) and accept the
      [code](../blob/main/CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
