### PR TITLE
Set example orb minor version to 1.1

### DIFF
--- a/docs/11-circleci/01-getting-started.mdx
+++ b/docs/11-circleci/01-getting-started.mdx
@@ -48,7 +48,7 @@ will fail. For more details, head to the [Activation](/docs/circleci/activation)
 Create a `.circleci/config.yml` file in the root of your repository and follow these steps:
 
 1. Import the [Unity Orb](https://circleci.com/developer/orbs/orb/game-ci/unity) and fix it to a
-   `minor` version (e.g. `1.16`) to avoid receiving updates with breaking changes:
+   `minor` version (e.g. `1.1`) to avoid receiving updates with breaking changes:
 
 ```yaml
 version: 2.1


### PR DESCRIPTION
#### Changes

Set example minor version to 1.1 instead of 1.16 based on available version here: https://circleci.com/developer/orbs/orb/game-ci/unity