### PR TITLE
Added documentation for fetching submodules

### DIFF
--- a/docs/11-circleci/03-build.mdx
+++ b/docs/11-circleci/03-build.mdx
@@ -287,7 +287,7 @@ workflows:
 
 #### fetch-submodules
 
-Whether to fetch git submodules relating to the project repository
+Whether to fetch git submodules relating to the project repository.
 
 ```yaml
 version: 2.1

--- a/docs/11-circleci/03-build.mdx
+++ b/docs/11-circleci/03-build.mdx
@@ -285,6 +285,27 @@ workflows:
 - _Required_: `false`
 - _Type_: `boolean`
 
+#### fetch-submodules
+
+Whether to fetch git submodules relating to the project repository
+
+```yaml
+version: 2.1
+
+orbs:
+  unity: game-ci/unity@x.y
+
+workflows:
+  build-unity-project:
+    jobs:
+      - unity/build:
+          fetch-submodules: true
+```
+
+- _Default_: `false`
+- _Required_: `false`
+- _Type_: `boolean`
+
 #### unity-license-var-name
 
 The name of the environment variable holding the license set in your


### PR DESCRIPTION
#### Changes

- Added documentation for fetching git submodules under unity-orb project 
[[relating unity-orb PR-41]](https://github.com/game-ci/unity-orb/pull/41)

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../blob/main/CONTRIBUTING.md) and accept the
      [code](../blob/main/CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
