### PR TITLE
fix: macOS example in CCI's build job

### DIFF
--- a/docs/11-circleci/03-build.mdx
+++ b/docs/11-circleci/03-build.mdx
@@ -435,16 +435,15 @@ workflows:
 
       # macOS IL2CPP
       - unity/build:
-          name: 'build-Windows64-il2cpp'
-          step-name: 'Build StandaloneWindows64 il2cpp'
+          name: 'build-osx-il2cpp'
+          step-name: 'Build macOS IL2CPP'
           unity-license-var-name: 'UNITY_ENCODED_LICENSE'
           unity-username-var-name: 'UNITY_USERNAME'
           unity-password-var-name: 'UNITY_PASSWORD'
           executor:
-            name: 'unity/windows-2019'
-            size: 'large'
+            name: 'unity/macos'
+            resource_class: 'large'
             editor_version: '2021.3.2f1'
-            target_platform: 'windows-il2cpp'
           project-path: 'Unity2D-Demo-Game-CI-CD/src'
           build-target: StandaloneWindows64
           compress: true
@@ -641,18 +640,17 @@ workflows:
 
       # macOS IL2CPP
       - unity/build:
-          name: 'build-Windows64-il2cpp'
-          step-name: 'Build StandaloneWindows64 il2cpp'
+          name: 'build-osx-il2cpp'
+          step-name: 'Build macOS IL2CPP'
           unity-serial-var-name: 'UNITY_SERIAL'
           unity-username-var-name: 'UNITY_USERNAME'
           unity-password-var-name: 'UNITY_PASSWORD'
           executor:
-            name: 'unity/windows-2019'
-            size: 'large'
+            name: 'unity/macos'
+            resource_class: 'large'
             editor_version: '2021.3.2f1'
-            target_platform: 'windows-il2cpp'
           project-path: 'Unity2D-Demo-Game-CI-CD/src'
-          build-target: StandaloneWindows64
+          build-target: StandaloneOSX
           compress: true
           context: unity
 ```


### PR DESCRIPTION
#### Changes

- Fix CircleCI's build example for macOS

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../blob/main/CONTRIBUTING.md) and accept the
      [code](../blob/main/CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
