### PR TITLE
fix: add -w option to base64 command in circleci activation process

### DIFF
--- a/docs/11-circleci/02-activation.mdx
+++ b/docs/11-circleci/02-activation.mdx
@@ -78,7 +78,7 @@ Encode the contents of your `Unity_v20XX.x.ulf` file to base64. If you have the 
 line utility you can use:
 
 ```
-cat Unity_v20XX.x.ulf | base64
+cat Unity_v20XX.x.ulf | base64 -w 0
 ```
 
 #### Configuring your Context


### PR DESCRIPTION
#### Changes

- In order to disable line wrapping, add `-w 0` option to the base64 command in the CircleCI activation process

#### Checklist

<!-- please check all items and add your own -->

- [X] Read the contribution [guide](../blob/main/CONTRIBUTING.md) and accept the
      [code](../blob/main/CODE_OF_CONDUCT.md) of conduct
- [X] Readme (updated or not needed)
- [X] Tests (added, updated or not needed)
