### PR TITLE
Update docs to reflect changes in unity builder PR#505

### DIFF
--- a/docs/03-github/04-builder.mdx
+++ b/docs/03-github/04-builder.mdx
@@ -292,7 +292,30 @@ Configure the android `versionCode`.
 When not specified, the version code is generated from the version using the
 `major * 1000000 + minor * 1000 + patch` scheme;
 
+#### androidExportType
+
+Set this flag to `androidPackage` to build an apk, `androidAppBundle` for an aab, or
+`androidStudioProject` to build an Android Studio Project.
+
+```yaml
+- uses: game-ci/unity-builder@v2
+  with:
+    androidExportType: 'androidAppBundle'
+    androidKeystoreName: user.keystore
+    androidKeystoreBase64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+    androidKeystorePass: ${{ secrets.ANDROID_KEYSTORE_PASS }}
+    androidKeyaliasName: ${{ secrets.ANDROID_KEYALIAS_NAME }}
+    androidKeyaliasPass: ${{ secrets.ANDROID_KEYALIAS_PASS }}
+```
+
+You should also set all the Android Keystore options (see below). Refer to (this
+section)[/docs/github/deployment/android#3-generate-an-upload-key-and-keystore] for keystore setup.
+
+_**required:** `false`_ _**default:** `androidPackage`_
+
 #### androidAppBundle
+
+**[Deprecated] Please use androidExportType instead.**
 
 Set this flag to `true` to build '.aab' instead of '.apk'.
 
@@ -360,6 +383,12 @@ Configure the android target API level. If used, must be one of
 
 _**required:** `false`_ _**default:** `""`_
 
+#### androidSymbolType
+
+Export android symbols alongside the build. Can be set to `none`, `public`, or `debugging`.
+
+_**required:** `false`_ _**default:** `"none"`_
+
 #### sshAgent
 
 SSH Agent path to forward to the container.
@@ -401,6 +430,20 @@ _**required:** `false`_ _**default:** `false`_
 #### unityLicensingServer
 
 Sets the url to a unity license server for acquiring floating licenses.
+
+_**required:** `false`_ _**default:** `""`_
+
+#### cacheUnityInstallationOnMac
+
+Enables caching the Unity Hub and Editor installation for MacOS runners. This can significantly
+reduce project build times if you have enough available cache on Github Actions.
+
+_**required:** `false`_ _**default:** `false`_
+
+#### unityHubVersionOnMac
+
+Allows pinning the Unity Hub version used on MacOS runners. Should be of format `Major.Minor.Patch`,
+ie `3.4.0`. An empty string represents the latest available version on homebrew.
 
 _**required:** `false`_ _**default:** `""`_
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "engines": {
     "npm": "please-use-yarn",
     "yarn": ">= 1.22.4",
-    "node": "16.x"
+    "node": ">= 16.x"
   },
   "scripts": {
     "prepare": "lefthook install && npx husky uninstall -y",


### PR DESCRIPTION
#### Changes

- Add docs for `androidExportType`, `androidSymbolType`, `cacheUnityInstallationOnMac`, and `unityHubVersionOnMac`
- Add deprecation warning for `androidAppBundle`
- Update node requirements to allow for >=16.x

This supports game-ci/unity-builder#505

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../blob/main/CONTRIBUTING.md) and accept the
      [code](../blob/main/CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
