### PR TITLE
Add the need for custom .gitignore extensions to the Getting Started guide. (#365)

### DIFF
--- a/docs/02-getting-started/index.mdx
+++ b/docs/02-getting-started/index.mdx
@@ -18,7 +18,16 @@ your project.
 
 Be sure to **ignore any automatically generated files**, by adding the reference
 [.gitignore](https://github.com/github/gitignore/blob/master/Unity.gitignore) file to the root of
-your project.
+your project. Please note that you may have to extend this file by ignoring the temporary files created by the runners:
+
+These temporary files may cause jobs to fail with the error message 'branch is dirty'. This error means that the local branch that the runner is using has uncommitted changes at that point during the build (more info [https://game.ci/docs/troubleshooting/common-issues#branch-is-dirty]).
+Two common temporary folders that are created by gameci are `artifacts` and `CodeCoverage`. By adding these lines to your .gitignore, you can ignore their contents:
+
+```
+# Ignore temporaries from game-ci
+/[Aa]rtifacts/
+/[Cc]odeCoverage/
+```
 
 To **ensure large files are handled correctly** (in [LFS](https://git-lfs.github.com/)), you can add
 our reference

--- a/docs/02-getting-started/index.mdx
+++ b/docs/02-getting-started/index.mdx
@@ -18,13 +18,13 @@ your project.
 
 Be sure to **ignore any automatically generated files**, by adding the reference
 [.gitignore](https://github.com/github/gitignore/blob/master/Unity.gitignore) file to the root of
-your project. Please note that you may have to extend this file by ignoring the temporary files created by the runners:
+your project. Please note that you may have to extend this file to ignore the temporary files created by the runners, as the creation of these temporary files may cause a runners' local branch to become dirty (more info
+[here](/docs/troubleshooting/common-issues#branch-is-dirty])):
 
-These temporary files may cause jobs to fail with the error message 'branch is dirty'. This error means that the local branch that the runner is using has uncommitted changes at that point during the build (more info [https://game.ci/docs/troubleshooting/common-issues#branch-is-dirty]).
-Two common temporary folders that are created by gameci are `artifacts` and `CodeCoverage`. By adding these lines to your .gitignore, you can ignore their contents:
+Two common temporary folders that are created by GameCI are `artifacts` and `CodeCoverage`. You can ignore them by adding the following lines to your `.gitignore`:
 
 ```
-# Ignore temporaries from game-ci
+# Ignore temporaries from GameCI
 /[Aa]rtifacts/
 /[Cc]odeCoverage/
 ```

--- a/docs/02-getting-started/index.mdx
+++ b/docs/02-getting-started/index.mdx
@@ -18,10 +18,12 @@ your project.
 
 Be sure to **ignore any automatically generated files**, by adding the reference
 [.gitignore](https://github.com/github/gitignore/blob/master/Unity.gitignore) file to the root of
-your project. Please note that you may have to extend this file to ignore the temporary files created by the runners, as the creation of these temporary files may cause a runners' local branch to become dirty (more info
-[here](/docs/troubleshooting/common-issues#branch-is-dirty])):
+your project. Please note that you may have to extend this file to ignore the temporary files
+created by the runners, as the creation of these temporary files may cause a runners' local branch
+to become dirty (more info [here](/docs/troubleshooting/common-issues#branch-is-dirty])):
 
-Two common temporary folders that are created by GameCI are `artifacts` and `CodeCoverage`. You can ignore them by adding the following lines to your `.gitignore`:
+Two common temporary folders that are created by GameCI are `artifacts` and `CodeCoverage`. You can
+ignore them by adding the following lines to your `.gitignore`:
 
 ```
 # Ignore temporaries from GameCI

--- a/docs/09-troubleshooting/common-issues.mdx
+++ b/docs/09-troubleshooting/common-issues.mdx
@@ -174,9 +174,13 @@ There are multiple options to solve this.
 2. Find the files that are being modified and fix the source of the problem. **This is the
    recommended solution**.
 
-   The log should list the files that are considered modified on the now dirty branch. Locate the
-   modified files and figure out why they are being modified. Sometimes, it's because a `.meta` file
-   gets modified by unity when you open the project. If this is the case you can try this:
+   The log should list the files that are considered modified on the now dirty branch. 
+   First, double check that these are not temporary files created by the runners themselves (see the 
+   [Preparing the Project](https://game.ci/docs/getting-started/#preparing-the-project) section regarding
+   `.gitignore`).
+   If the files are instead project related, locate the modified files and figure out why they are being modified.
+   Sometimes, it's because a `.meta` file gets modified by unity when you open the project. If this is the case
+   you can try this:
 
    1. Clone your project in a new folder
    2. Open your project with unity

--- a/docs/09-troubleshooting/common-issues.mdx
+++ b/docs/09-troubleshooting/common-issues.mdx
@@ -174,13 +174,12 @@ There are multiple options to solve this.
 2. Find the files that are being modified and fix the source of the problem. **This is the
    recommended solution**.
 
-   The log should list the files that are considered modified on the now dirty branch. 
-   First, double check that these are not temporary files created by the runners themselves (see the 
+   The log should list the files that are considered modified on the now dirty branch. First, double
+   check that these are not temporary files created by the runners themselves (see the
    [Preparing the Project](/docs/getting-started/#preparing-the-project) section regarding
-   `.gitignore`).
-   If the files are instead project related, locate the modified files and figure out why they are being modified.
-   Sometimes, it's because a `.meta` file gets modified by unity when you open the project. If this is the case
-   you can try this:
+   `.gitignore`). If the files are instead project related, locate the modified files and figure out
+   why they are being modified. Sometimes, it's because a `.meta` file gets modified by unity when
+   you open the project. If this is the case you can try this:
 
    1. Clone your project in a new folder
    2. Open your project with unity

--- a/docs/09-troubleshooting/common-issues.mdx
+++ b/docs/09-troubleshooting/common-issues.mdx
@@ -176,7 +176,7 @@ There are multiple options to solve this.
 
    The log should list the files that are considered modified on the now dirty branch. 
    First, double check that these are not temporary files created by the runners themselves (see the 
-   [Preparing the Project](https://game.ci/docs/getting-started/#preparing-the-project) section regarding
+   [Preparing the Project](/docs/getting-started/#preparing-the-project) section regarding
    `.gitignore`).
    If the files are instead project related, locate the modified files and figure out why they are being modified.
    Sometimes, it's because a `.meta` file gets modified by unity when you open the project. If this is the case


### PR DESCRIPTION
#### Changes

This is a proposal to alter the `getting started` section and `common issues` to reflect that you need to add the temporary files created by the runners to your `.gitignore` to prevent their branch from becoming dirty.
It would resolve issue  #365 

- I expanded the `.gitignore` section in `01-getting-started.mdx`
- I extended the `dirty branch` common issue text to refer back to the section mentioned above.

#### Checklist

<!-- please check all items and add your own -->

- [ x ] Read the contribution [guide](../blob/main/CONTRIBUTING.md) and accept the
      [code](../blob/main/CODE_OF_CONDUCT.md) of conduct
- [ x ] Readme (updated or not needed)
- [ x ] Tests (added, updated or not needed)
