### PR TITLE
Fix discord link

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -2,11 +2,14 @@
   "hosting": {
     "public": "build",
     "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
-    "rewrites": [
+    "redirects": [
       {
         "source": "/discord",
-        "destination": "https://discord.gg/ZjpyhCRd"
-      },
+        "destination": "https://discord.gg/ZjpyhCRd",
+        "type": 301
+      }
+    ],
+    "rewrites": [
       {
         "source": "**",
         "destination": "/index.html"

--- a/firebase.json
+++ b/firebase.json
@@ -4,6 +4,10 @@
     "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
     "rewrites": [
       {
+        "source": "/discord",
+        "destination": "https://discord.gg/ZjpyhCRd"
+      },
+      {
         "source": "**",
         "destination": "/index.html"
       }


### PR DESCRIPTION
#### Changes

- Add a redirect from `/discord` to the discord invite. `/discord` is used as a shorthand of that very invite and was washed away when we moved from Vercel to Firebase.

See Firebase Hosting [priority order](https://firebase.google.com/docs/hosting/full-config#hosting_priority_order) to understand how the redirect resolves with regards to the rewrites.

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../blob/main/CONTRIBUTING.md) and accept the
      [code](../blob/main/CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [ ] Tests (added, updated or not needed)
