### PR TITLE
Update unity-test-runner docs for License Server

### DIFF
--- a/docs/03-github/03-test-runner.mdx
+++ b/docs/03-github/03-test-runner.mdx
@@ -66,9 +66,9 @@ floating license will be acquired before the tests run, and returned after.
 Example of use:
 
 ```yaml
-- uses: game-ci/unity-builder@v2
+- uses: game-ci/unity-test-runner@v2
   with:
-    targetPlatform: WebGL
+    projectPath: path/to/your/project
     unityLicensingServer: [url to your license server]
 ```
 


### PR DESCRIPTION
I spotted this while reading the docs, this is the only section from `unity-test-runner` that mentions `unity-builder`. I haven't tested this, but I think it might be a mistake. Could it be copy paste error?