### PR TITLE
Update steam.mdx

### DIFF
--- a/docs/03-github/06-deployment/steam.mdx
+++ b/docs/03-github/06-deployment/steam.mdx
@@ -101,8 +101,9 @@ possible to go through the MFA process only once by following these steps:
 1. Validate that the MFA process is complete by running `steamcmd +login <username> +quit` again. It
    should not ask for the MFA code again.
 1. The folder from which you run `steamcmd` will now contain an updated `config/config.vdf` file.
-   Use `cat config/config.vdf | base64 > config_base64.txt` on *Linux* to encode the file, if you are a
-   on *Windows* device, use `certutil -encode -f .\config\config.vdf tmp.b64 && findstr /v /c:- tmp.b64 > config_base64.txt`.
+   Use `cat config/config.vdf | base64 > config_base64.txt` on _Linux_ to encode the file, if you
+   are a on _Windows_ device, use
+   `certutil -encode -f .\config\config.vdf tmp.b64 && findstr /v /c:- tmp.b64 > config_base64.txt`.
    Copy the contents of `config_base64.txt` to a GitHub Secret `STEAM_CONFIG_VDF`.
 1. `If:` when running the action you recieve another MFA code via email, run
    `steamcmd +set_steam_guard_code <code>` on your local machine and repeat the `config.vdf`

--- a/docs/03-github/06-deployment/steam.mdx
+++ b/docs/03-github/06-deployment/steam.mdx
@@ -101,8 +101,9 @@ possible to go through the MFA process only once by following these steps:
 1. Validate that the MFA process is complete by running `steamcmd +login <username> +quit` again. It
    should not ask for the MFA code again.
 1. The folder from which you run `steamcmd` will now contain an updated `config/config.vdf` file.
-   Use `cat config/config.vdf | base64 > config_base64.txt` to encode the file. Copy the contents of
-   `config_base64.txt` to a GitHub Secret `STEAM_CONFIG_VDF`.
+   Use `cat config/config.vdf | base64 > config_base64.txt` on *Linux* to encode the file, if you are a
+   on *Windows* device, use `certutil -encode -f .\config\config.vdf tmp.b64 && findstr /v /c:- tmp.b64 > config_base64.txt`.
+   Copy the contents of `config_base64.txt` to a GitHub Secret `STEAM_CONFIG_VDF`.
 1. `If:` when running the action you recieve another MFA code via email, run
    `steamcmd +set_steam_guard_code <code>` on your local machine and repeat the `config.vdf`
    encoding and replace secret `STEAM_CONFIG_VDF` with its contents.


### PR DESCRIPTION

#### Changes
- Added the *Windows* version of the command for encoding the config.vdf file to base64 to the documentation.
   > `certutil -encode -f .\config\config.vdf tmp.b64 && findstr /v /c:- tmp.b64 > config_base64.txt`

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../blob/main/CONTRIBUTING.md) and accept the
      [code](../blob/main/CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
