### PR TITLE
Bump unity-test-runner version to v3

### DIFF
--- a/docs/03-github/01-getting-started.mdx
+++ b/docs/03-github/01-getting-started.mdx
@@ -90,7 +90,7 @@ jobs:
 
       # Test
       - name: Run tests
-        uses: game-ci/unity-test-runner@v2
+        uses: game-ci/unity-test-runner@v3
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
         with:
@@ -160,7 +160,7 @@ jobs:
 
       # Test
       - name: Run tests
-        uses: game-ci/unity-test-runner@v2
+        uses: game-ci/unity-test-runner@v3
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
         with:
@@ -233,7 +233,7 @@ jobs:
             Library-${{ matrix.projectPath }}-${{ matrix.targetPlatform }}-
             Library-${{ matrix.projectPath }}-
             Library-
-      - uses: game-ci/unity-test-runner@v2
+      - uses: game-ci/unity-test-runner@v3
         id: testRunner
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}

--- a/docs/03-github/03-test-runner.mdx
+++ b/docs/03-github/03-test-runner.mdx
@@ -29,7 +29,7 @@ license file and add it as a secret.
 Then, define the test step as follows:
 
 ```yaml
-- uses: game-ci/unity-test-runner@v2
+- uses: game-ci/unity-test-runner@v3
   env:
     UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
   with:
@@ -48,7 +48,7 @@ Make sure you have set up these variables in the activation step.
 Define the test step as follows:
 
 ```yaml
-- uses: game-ci/unity-test-runner@v2
+- uses: game-ci/unity-test-runner@v3
   env:
     UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
     UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
@@ -66,7 +66,7 @@ floating license will be acquired before the tests run, and returned after.
 Example of use:
 
 ```yaml
-- uses: game-ci/unity-test-runner@v2
+- uses: game-ci/unity-test-runner@v3
   with:
     projectPath: path/to/your/project
     unityLicensingServer: [url to your license server]
@@ -89,7 +89,7 @@ To indicate that the test runner is being run for a Unity package rather than a 
 the [`packageMode`](#packagemode) configuration option to `true`.
 
 ```yaml
-- uses: game-ci/unity-test-runner@v2
+- uses: game-ci/unity-test-runner@v3
   with:
     packageMode: true
 ```
@@ -100,7 +100,7 @@ Make sure that you explicitly pass the [`unityVersion`](#unityversion) argument,
 for the test runner to test Unity packages.
 
 ```yaml
-- uses: game-ci/unity-test-runner@v2
+- uses: game-ci/unity-test-runner@v3
   with:
     unityVersion: [your desired Unity version]
 ```
@@ -160,7 +160,7 @@ in order to view the tests results from
 [a check run](https://docs.github.com/en/rest/guides/getting-started-with-the-checks-api#about-check-runs).
 
 ```yaml
-- uses: game-ci/unity-test-runner@v2
+- uses: game-ci/unity-test-runner@v3
   with:
     githubToken: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -193,7 +193,7 @@ You can specify a different `artifactsPath` in the test runner and reference thi
 `id` of the test step.
 
 ```yaml
-- uses: game-ci/unity-test-runner@v2
+- uses: game-ci/unity-test-runner@v3
   id: myTestStep
 ```
 
@@ -266,7 +266,7 @@ Specific docker image that should be used for testing the project. If packageMod
 image must have [`jq`](https://jqlang.github.io/jq/) installed.
 
 ```yaml
-- uses: game-ci/unity-test-runner@v2
+- uses: game-ci/unity-test-runner@v3
   with:
     customImage: 'unityci/editor:2020.1.14f1-base-0'
 ```
@@ -293,7 +293,7 @@ Parameters must start with a hyphen (`-`) and may be followed by a value (withou
 Parameters without a value will be considered booleans (with a value of true).
 
 ```yaml
-- uses: game-ci/unity-test-runner@v2
+- uses: game-ci/unity-test-runner@v3
   with:
     customParameters: -profile SomeProfile -someBoolean -someValue exampleValue
 ```
@@ -440,7 +440,7 @@ jobs:
           key: Library-${{ matrix.projectPath }}
           restore-keys: |
             Library-
-      - uses: game-ci/unity-test-runner@v2
+      - uses: game-ci/unity-test-runner@v3
         id: tests
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
@@ -490,7 +490,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           lfs: true
-      - uses: game-ci/unity-test-runner@v2
+      - uses: game-ci/unity-test-runner@v3
         id: tests
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}


### PR DESCRIPTION
#### Changes

- Bumps all usages of the `game-ci/unity-test-runner` GitHub action to the newer `v3`.

#### Checklist

- [x] Read the contribution [guide](../blob/main/CONTRIBUTING.md) and accept the
      [code](../blob/main/CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
