### PR TITLE
Fix free-disk-space version in example

### DIFF
--- a/docs/03-github/04-builder.mdx
+++ b/docs/03-github/04-builder.mdx
@@ -612,7 +612,7 @@ jobs:
           key: Library-${{ matrix.targetPlatform }}
           restore-keys: Library-
       - if: matrix.targetPlatform == 'Android'
-        uses: jlumbroso/free-disk-space@v1.2.0
+        uses: jlumbroso/free-disk-space@v1.3.0
       - uses: game-ci/unity-builder@v3
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}


### PR DESCRIPTION
Old version 1.2.0 throws the error `E: Unable to locate package google-cloud-sdk`, version 1.3.0 fixes this. Tested here: https://github.com/JohannesDeml/Unity-GameJam-Template/commit/60af3abdad4ede3bd38a3055535c8570b15e81a7

#### Changes

- Update `free-disk-space` from version 1.2 to 1.3 in full example to make it work again

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../blob/main/CONTRIBUTING.md) and accept the
      [code](../blob/main/CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
