### PR TITLE
Fix broken link causing pipeline to fail

### DIFF
--- a/docs/12-self-hosting/01-overview.mdx
+++ b/docs/12-self-hosting/01-overview.mdx
@@ -86,7 +86,7 @@ workflows are supported.
 
 - [Manual Ubuntu 22.04 Setup](./04-host-provisioning/02-ubuntu-setup.mdx)
 - [Manual Debian 12 Setup](./04-host-provisioning/01-debian-setup.mdx)
-- [Declarative provisioning via Cloud-Init](./04-host-provisioning/03-cloud-init/01-about.mdx)
+- [Declarative provisioning via Cloud-Init](./04-host-provisioning/03-cloud-init.mdx)
 
 ### Runner Application Installation
 

--- a/docs/12-self-hosting/01-overview.mdx
+++ b/docs/12-self-hosting/01-overview.mdx
@@ -2,7 +2,7 @@
 toc_max_heading_level: 4
 ---
 
-# About Self-Hosting
+# Overview
 
 Projects often encounter a constraint or requirement which makes free-tier hosted CI/CD runners
 insufficient for their needs. In these cases hosting your own CI/CD runner can be a viable

--- a/docs/12-self-hosting/03-host-creation/03-QEMU/02-linux-cloudimage.mdx
+++ b/docs/12-self-hosting/03-host-creation/03-QEMU/02-linux-cloudimage.mdx
@@ -95,7 +95,7 @@ customize the cloud-image immediately upon booting, prior to user-space initiali
 
   See the [Cloud-Init](https://cloudinit.readthedocs.io/en/latest/topics/examples.html) official
   docs for more information about Cloud-Init. More advanced templates are available in the
-  [Host Provisioning](../../04-host-provisioning/03-Cloud-Init.mdx) directory.
+  [Host Provisioning](../../04-host-provisioning/03-cloud-init.mdx) directory.
 
   ```bash
   VM_KEY=$(cat runner.pub)


### PR DESCRIPTION
Draft


Fixes:  

> Docs markdown link couldn't be resolved: (./04-host-provisioning/03-cloud-init/01-about.mdx) in "/home/runner/work/documentation/documentation/docs/12-self-hosting/01-overview.mdx" for version current

#### Changes

- change header 1 of 01-overview.mdx back to 'Overview' from 'about self hosting'

- change an instance of 'Cloud-Init' to 'cloud-init'

- change a bad internal link with an outdated file ref

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../blob/main/CONTRIBUTING.md) and accept the
      [code](../blob/main/CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
