### PR TITLE
Fix iOS build App Store (permission issue)

### DIFF
--- a/docs/03-github/06-deployment/ios.mdx
+++ b/docs/03-github/06-deployment/ios.mdx
@@ -480,6 +480,7 @@ jobs:
           eval "$(ssh-agent -s)"
           ssh-add - <<< "${MATCH_DEPLOY_KEY}"
           find $IOS_BUILD_PATH -type f -name "**.sh" -exec chmod +x {} \;
+          find $IOS_BUILD_PATH -type f -iname "usymtool" -exec chmod +x {} \;
           bundle install
           bundle exec fastlane ios release
 

--- a/versioned_docs/version-2/03-github/06-deployment/ios.mdx
+++ b/versioned_docs/version-2/03-github/06-deployment/ios.mdx
@@ -480,6 +480,7 @@ jobs:
           eval "$(ssh-agent -s)"
           ssh-add - <<< "${MATCH_DEPLOY_KEY}"
           find $IOS_BUILD_PATH -type f -name "**.sh" -exec chmod +x {} \;
+          find $IOS_BUILD_PATH -type f -iname "usymtool" -exec chmod +x {} \;
           bundle install
           bundle exec fastlane ios release
 

--- a/versioned_docs/version-3/03-github/06-deployment/ios.mdx
+++ b/versioned_docs/version-3/03-github/06-deployment/ios.mdx
@@ -480,6 +480,7 @@ jobs:
           eval "$(ssh-agent -s)"
           ssh-add - <<< "${MATCH_DEPLOY_KEY}"
           find $IOS_BUILD_PATH -type f -name "**.sh" -exec chmod +x {} \;
+          find $IOS_BUILD_PATH -type f -iname "usymtool" -exec chmod +x {} \;
           bundle install
           bundle exec fastlane ios release
 


### PR DESCRIPTION
While following the documentation I encountered an issue while building for iOS for App Store / Testflight distribution that necessitated a change to the permission of the file "usymtool".

Here's the log:

```
warning: Run script build phase 'Unity Process symbols' will be run during every build because it does not specify any outputs. To address this warning, either add output dependencies to the script phase, or configure it to run in every build by unchecking "Based on dependency analysis" in the script phase. (in target 'Unity-iPhone' from project 'Unity-iPhone')
** ARCHIVE FAILED **


The following build commands failed:
	PhaseScriptExecution Unity\ Process\ symbols /Users/runner/Library/Developer/Xcode/DerivedData/Unity-iPhone-fspqhayqvhrnvthcqgdyuzoxkiww/Build/Intermediates.noindex/ArchiveIntermediates/Unity-iPhone/IntermediateBuildFilesPath/Unity-iPhone.build/Release-iphoneos/UnityFramework.build/Script-C9134D649CBEB69C06B62AC4.sh (in target 'UnityFramework' from project 'Unity-iPhone')
(1 failure)
[17:13:57]: Exit status: 65
```

As you can see, not much info, but the problem was with the "Unity Process symbols" step which call "process_symbols.sh" which call "usymtool", which had it's execute permission lost while packaging the artifact.

My Unity version 2021.1.28f1 (iOS)

#### Changes

- Added permission fix when building for App Store (iOS)

#### Checklist

- [x] Read the contribution [guide](../blob/main/CONTRIBUTING.md) and accept the
      [code](../blob/main/CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)

