### PR TITLE
Change buildscript to only write version if it should be set

### DIFF
--- a/example/BuildScript.cs
+++ b/example/BuildScript.cs
@@ -20,9 +20,15 @@ namespace UnityBuilderAction
             Dictionary<string, string> options = GetValidatedOptions();
 
             // Set version for this build
-            PlayerSettings.bundleVersion = options["buildVersion"];
-            PlayerSettings.macOS.buildNumber = options["buildVersion"];
-            PlayerSettings.Android.bundleVersionCode = int.Parse(options["androidVersionCode"]);
+            if(options.TryGetValue("buildVersion", out string buildVersion) && buildVersion != "none")
+            {
+                PlayerSettings.bundleVersion = buildVersion;
+                PlayerSettings.macOS.buildNumber = buildVersion;
+            }
+            if(options.TryGetValue("androidVersionCode", out string versionCode) && versionCode != "0")
+            {
+                PlayerSettings.Android.bundleVersionCode = int.Parse(options["androidVersionCode"]);
+            }
 
             // Apply build target
             var buildTarget = (BuildTarget) Enum.Parse(typeof(BuildTarget), options["buildTarget"]);


### PR DESCRIPTION
When versioning: None is set the version values should not be overwritten with "none", but kept as is, since that matches the documentation

#### Changes

- Set the buildVersion and and bundleVersionCode only if the value makes sense

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../blob/main/CONTRIBUTING.md) and accept the
      [code](../blob/main/CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
