### PR TITLE
Update docs around floating licensing configurations

### DIFF
--- a/docs/03-github/02-activation.mdx
+++ b/docs/03-github/02-activation.mdx
@@ -85,6 +85,20 @@ Example of use:
     unityLicensingServer: [url to your license server]
 ```
 
+Additionally, if your licensing server has multiple product licenses configured, you can specify the
+product identifier(s) that will be requested. More information about multiple products can be found
+[here](https://docs.unity.com/licensing/en-us/manual/ServerSetup-test#Support_for_multiple_product_licenses).
+
+Example of use:
+
+```yaml
+- uses: game-ci/unity-builder@v4
+  with:
+    targetPlatform: WebGL
+    unityLicensingServer: [url to your license server]
+    unityLicensingProductIds: [comma separated product ids]
+```
+
 ## Optional steps
 
 - Verify your license using [Activate](https://github.com/marketplace/actions/unity-activate).

--- a/docs/03-github/03-test-runner.mdx
+++ b/docs/03-github/03-test-runner.mdx
@@ -74,6 +74,20 @@ Example of use:
     unityLicensingServer: [url to your license server]
 ```
 
+Additionally, if your licensing server has multiple product licenses configured, you can specify the
+product identifier(s) that will be requested. More information about multiple products can be found
+[here](https://docs.unity.com/licensing/en-us/manual/ServerSetup-test#Support_for_multiple_product_licenses).
+
+Example of use:
+
+```yaml
+- uses: game-ci/unity-test-runner@v4
+  with:
+    projectPath: path/to/your/project
+    unityLicensingServer: [url to your license server]
+    unityLicensingProductIds: [comma separated product ids]
+```
+
 That is all you need to test your project.
 
 ## Testing Projects with a private scoped registry
@@ -556,6 +570,19 @@ _**required:** `false`_ _**default:** `false`_
 
 User and optionally group (user or user:group or uid:gid) to give ownership of the resulting build
 artifacts.
+
+_**required:** `false`_ _**default:** `""`_
+
+#### unityLicensingServer
+
+Sets the url to a unity license server for acquiring floating licenses.
+
+_**required:** `false`_ _**default:** `""`_
+
+#### unityLicensingProductIds
+
+Comma separated list of license product identifiers to request licenses for from the unity license
+server.
 
 _**required:** `false`_ _**default:** `""`_
 

--- a/docs/03-github/04-builder.mdx
+++ b/docs/03-github/04-builder.mdx
@@ -83,6 +83,20 @@ Example of use:
     unityLicensingServer: [url to your license server]
 ```
 
+Additionally, if your licensing server has multiple product licenses configured, you can specify the
+product identifier(s) that will be requested. More information about multiple products can be found
+[here](https://docs.unity.com/licensing/en-us/manual/ServerSetup-test#Support_for_multiple_product_licenses).
+
+Example of use:
+
+```yaml
+- uses: game-ci/unity-builder@v4
+  with:
+    targetPlatform: WebGL
+    unityLicensingServer: [url to your license server]
+    unityLicensingProductIds: [comma separated product ids]
+```
+
 That is all you need to build your project.
 
 By default, the enabled scenes from the project's settings will be built.
@@ -434,6 +448,13 @@ _**required:** `false`_ _**default:** `false`_
 #### unityLicensingServer
 
 Sets the url to a unity license server for acquiring floating licenses.
+
+_**required:** `false`_ _**default:** `""`_
+
+#### unityLicensingProductIds
+
+Comma separated list of license product identifiers to request licenses for from the unity license
+server.
 
 _**required:** `false`_ _**default:** `""`_
 


### PR DESCRIPTION
#### Changes

- add examples in activation, unity builder v4, and unity test runner v3 docs
- adds docs for `unityLicensingProductIds` parameters introduced in https://github.com/game-ci/unity-builder/pull/661 and https://github.com/game-ci/unity-test-runner/pull/282
- add missing test runner v3 parameter for `unityLicensingServer`

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../blob/main/CONTRIBUTING.md) and accept the
      [code](../blob/main/CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
