### PR TITLE
Add instructions about setting preprocessor macros

### DIFF
--- a/docs/03-github/04-builder.mdx
+++ b/docs/03-github/04-builder.mdx
@@ -667,6 +667,30 @@ that directory. This action must be done before running the game-ci/unity-builde
     echo "token = \"${{ secrets.NPM_TOKEN }}\"" >> .upmconfig.toml
 ```
 
+## Using preprocessor macros
+
+If needed, Unity preprocessor directives can be set by adding a step to the build.
+
+```yaml
+steps:
+  - name: Apply csc.rsp (pre-processor symbols)
+    run: echo -define:MY_SYMBOL >> Assets/csc.rsp
+```
+
+To avoid warnings about "unapplied changes", add `Assets/csc.rsp` in your `.gitignore`
+
+Once set, you can then reference these preprocessor directives in code:
+
+```c
+void Start() {
+#if MY_SYMBOL
+  GetComponent<TMP_Text>().text = "I have a symbol!";
+#else
+  GetComponent<TMP_Text>().text = "I do not have a symbol...";
+#endif
+}
+```
+
 ## Complete example
 
 A complete workflow that builds every available platform could look like this:


### PR DESCRIPTION
#### Changes

Added instructions about setting preprocessor directives in Unity, as described in https://github.com/game-ci/documentation/issues/473

#### Checklist

- [X] Read the contribution [guide](../blob/main/CONTRIBUTING.md) and accept the
      [code](../blob/main/CODE_OF_CONDUCT.md) of conduct
- [X] Readme (updated or not needed)
- [X] Tests (added, updated or not needed)

Tested locally:
<img width="1035" alt="image" src="https://github.com/user-attachments/assets/30148713-4086-47ae-9ef2-428567eaecde">

