### PR TITLE
Remove PricingSection from home page

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -5,7 +5,7 @@ import OpeningSection from '@site/src/components/pages/home/section/opening-sect
 import SponsorsSection from '@site/src/components/pages/home/section/sponsors-section';
 // import VisualRepresentationOfWhatWeDoSection from '@site/src/components/pages/home/section/visual-representation-of-what-we-do';
 // import OurVisionSection from '@site/src/components/pages/home/section/our-vision-section';
-import PricingSection from '@site/src/components/pages/home/section/pricing-section';
+// import PricingSection from '@site/src/components/pages/home/section/pricing-section';
 // import CodeExamplesSection from '@site/src/components/pages/home/section/code-examples-section';
 import WhoIsUsingGameCiSection from '@site/src/components/pages/home/section/who-is-using-game-ci-section';
 // import GallerySection from '@site/src/components/pages/home/section/gallery-section';

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -20,7 +20,7 @@ export default function Home(): React.JSX.Element {
       <SponsorsSection />
       <WhoIsUsingGameCiSection />
       {/* <CodeExamplesSection /> */}
-      <PricingSection />
+      {/* <PricingSection /> */}
       {/* <GallerySection /> */}
     </Layout>
   );


### PR DESCRIPTION
#### Changes

- Commented out a component on the home page as it didn't really do much yet (always 0 / free)


![CleanShot 2024-11-17 at 20 12 30@2x](https://github.com/user-attachments/assets/fdcb62ad-afa7-4cd7-81d8-a2105d00026f)

![CleanShot 2024-11-17 at 20 12 36@2x](https://github.com/user-attachments/assets/f5909455-0fe3-4ff2-a8ac-61f0d09ba6d1)

It's nice, but since it's not really working properly yet (data is not connected to it) I think it's better to hide it for now.

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../blob/main/CONTRIBUTING.md) and accept the
      [code](../blob/main/CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The `PricingSection` component has been temporarily removed from the homepage, streamlining the user interface.
  
- **Bug Fixes**
	- Resolved issues related to the display of the `PricingSection` on the homepage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->