### PR TITLE
fix: Update LinkButton styling to use grid layout

### DIFF
--- a/src/components/pages/home/section/getting-started.tsx
+++ b/src/components/pages/home/section/getting-started.tsx
@@ -30,7 +30,7 @@ type LinkButtonProps = {
 const LinkButton = ({ url, logo: Logo }: LinkButtonProps) => (
   <Link
     to={url}
-    className="group flex items-center justify-center border-gray-600 border-solid rounded-sm border-2 px-6 py-3 w-[180px] h-[70px] transition-all duration-200 hover:scale-110 hover:bg-gray-600"
+    className="group grid place-items-center border-gray-600 border-solid rounded-sm border-2 px-6 py-3 w-[180px] h-[70px] transition-all duration-200 hover:scale-110 hover:bg-gray-600"
   >
     <Logo className="fill-brand-text-light dark:fill-brand-text-dark group-hover:fill-white" />
   </Link>


### PR DESCRIPTION
Closes #493 

This pull request includes a small change to the `src/components/pages/home/section/getting-started.tsx` file. The change modifies the `className` property of the `Link` component to use a CSS grid layout instead of flexbox.

* [`src/components/pages/home/section/getting-started.tsx`](diffhunk://#diff-7023e87aec914b4d456a282e24452a3e7d6ae04286014c1ace7fa0bebc27a468L33-R33): Changed the `className` property in the `LinkButton` component from `flex` to `grid` for centering items.

![CleanShot 2025-01-15 at 18 38 52@2x](https://github.com/user-attachments/assets/ec0b0c07-c7bb-40db-bcde-46227f58867d)
