### PR TITLE
fix powershell cmd in 02-activation.mdx

### DIFF
--- a/docs/05-gitlab/02-activation.mdx
+++ b/docs/05-gitlab/02-activation.mdx
@@ -108,7 +108,12 @@ If you have trouble locating the `.ulf` file, follow these steps:
    On Windows using Powershell:
 
    ```powershell
-   Get-Content Unity_lic.ulf | Select-String -Pattern 'DeveloperData' | ForEach-Object { $_ -replace '.*Value="([^"]+)".*', '$1' } | [System.Convert]::FromBase64String($_)
+   Get-Content Unity_lic.ulf | Select-String -Pattern 'DeveloperData' | ForEach-Object {
+    if ($_ -match 'Value="([^"]+)"') {
+        $base64String = $matches[1]
+        [System.Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($base64String))
+    }
+   }
    ```
 
 :::info Expected Serial Format


### PR DESCRIPTION
Fixes error from existing cmd:
```
At line:1 char:131
+ ... .*Value="([^"]+)".*', '$1' } | [System.Convert]::FromBase64String($_)
+                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Expressions are only allowed as the first element of a pipeline.
    + CategoryInfo          : ParserError: (:) [], ParentContainsErrorRecordException
    + FullyQualifiedErrorId : ExpressionsMustBeFirstInPipeline
```
#### Changes

Confirmation it worked:
![image](https://github.com/user-attachments/assets/e11dc658-2ad1-4f6b-9f9f-ecd54f29d5d3)


- ...

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../blob/main/CONTRIBUTING.md) and accept the
      [code](../blob/main/CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced the data extraction process by adding a validation step before decoding, ensuring more reliable and accurate processing of activation information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->