### PR TITLE
Upgrade artifacts to v4 on builder.mdx

### DIFF
--- a/docs/03-github/04-builder.mdx
+++ b/docs/03-github/04-builder.mdx
@@ -734,7 +734,7 @@ jobs:
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
         with:
           targetPlatform: ${{ matrix.targetPlatform }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: Build-${{ matrix.targetPlatform }}
           path: build/${{ matrix.targetPlatform }}


### PR DESCRIPTION
#### Changes

Bumped `actions/upload-artifact` from v3 to v4 to use the latest version. 
Reason? Avoid this error: `Error: Missing download info for actions/upload-artifact@v3`

#### Checklist
<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../blob/main/CONTRIBUTING.md) and accept the
      [code](../blob/main/CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
