### PR TITLE
Add information on where to find `config.vdf` and needing to refresh it to fix `ERROR (License expired)`

### DIFF
--- a/docs/03-github/06-deployment/steam.mdx
+++ b/docs/03-github/06-deployment/steam.mdx
@@ -101,11 +101,11 @@ possible to go through the MFA process only once by following these steps:
    code. If so, type in the MFA code that was emailed to your builder account's email address.
 1. Validate that the MFA process is complete by running `steamcmd +login <username> +quit` again. It
    should not ask for the MFA code again.
-1. The folder from which you run `steamcmd` will now contain an updated `config/config.vdf` file.
-   Use `cat config/config.vdf | base64 > config_base64.txt` on _Linux_ to encode the file, if you
-   are a on _Windows_ device, use
-   `certutil -encode -f .\config\config.vdf tmp.b64 && findstr /v /c:- tmp.b64 > config_base64.txt`.
-   Copy the contents of `config_base64.txt` to a GitHub Secret `STEAM_CONFIG_VDF`.
+1. The folder from which you run `steamcmd` (or `~/Library/Application Support/Steam` on macOS)
+   will now contain an updated `config/config.vdf` file. Use `cat config/config.vdf | base64 > config_base64.txt`
+  on _Linux_ to encode the file, if you are a on _Windows_ device, use
+  `certutil -encode -f .\config\config.vdf tmp.b64 && findstr /v /c:- tmp.b64 > config_base64.txt`.
+  Copy the contents of `config_base64.txt` to a GitHub Secret `STEAM_CONFIG_VDF`.
 1. If when running the action you recieve another MFA code via email, run
    `steamcmd +set_steam_guard_code <code>` on your local machine and repeat the `config.vdf`
    encoding and replace secret `STEAM_CONFIG_VDF` with its contents.

--- a/docs/03-github/06-deployment/steam.mdx
+++ b/docs/03-github/06-deployment/steam.mdx
@@ -101,16 +101,17 @@ possible to go through the MFA process only once by following these steps:
    code. If so, type in the MFA code that was emailed to your builder account's email address.
 1. Validate that the MFA process is complete by running `steamcmd +login <username> +quit` again. It
    should not ask for the MFA code again.
-1. The folder from which you run `steamcmd` (or `~/Library/Application Support/Steam` on macOS)
-   will now contain an updated `config/config.vdf` file. Use `cat config/config.vdf | base64 > config_base64.txt`
-   on _Linux_ to encode the file, if you are on a _Windows_ device, use
+1. The folder from which you run `steamcmd` (or `~/Library/Application Support/Steam` on macOS) will
+   now contain an updated `config/config.vdf` file. Use
+   `cat config/config.vdf | base64 > config_base64.txt` on _Linux_ to encode the file, if you are on
+   a _Windows_ device, use
    `certutil -encode -f .\config\config.vdf tmp.b64 && findstr /v /c:- tmp.b64 > config_base64.txt`.
    Copy the contents of `config_base64.txt` to a GitHub Secret `STEAM_CONFIG_VDF`.
 1. If when running the action you receive another MFA code via email, run
    `steamcmd +set_steam_guard_code <code>` on your local machine and repeat the `config.vdf`
    encoding and replace secret `STEAM_CONFIG_VDF` with its contents.
-1. You will also need to repeat the process if the action fails with `ERROR (License expired)`
-   when logging into Steam.
+1. You will also need to repeat the process if the action fails with `ERROR (License expired)` when
+   logging into Steam.
 
 If your builder account uses MFA through the Steam Guard App, the `steam-deploy` app can use a TOTP
 instead of the above configuration. Generating a TOTP is outside the scope of this guide, as it is

--- a/docs/03-github/06-deployment/steam.mdx
+++ b/docs/03-github/06-deployment/steam.mdx
@@ -103,9 +103,9 @@ possible to go through the MFA process only once by following these steps:
    should not ask for the MFA code again.
 1. The folder from which you run `steamcmd` (or `~/Library/Application Support/Steam` on macOS)
    will now contain an updated `config/config.vdf` file. Use `cat config/config.vdf | base64 > config_base64.txt`
-  on _Linux_ to encode the file, if you are a on _Windows_ device, use
-  `certutil -encode -f .\config\config.vdf tmp.b64 && findstr /v /c:- tmp.b64 > config_base64.txt`.
-  Copy the contents of `config_base64.txt` to a GitHub Secret `STEAM_CONFIG_VDF`.
+   on _Linux_ to encode the file, if you are a on _Windows_ device, use
+   `certutil -encode -f .\config\config.vdf tmp.b64 && findstr /v /c:- tmp.b64 > config_base64.txt`.
+   Copy the contents of `config_base64.txt` to a GitHub Secret `STEAM_CONFIG_VDF`.
 1. If when running the action you recieve another MFA code via email, run
    `steamcmd +set_steam_guard_code <code>` on your local machine and repeat the `config.vdf`
    encoding and replace secret `STEAM_CONFIG_VDF` with its contents.

--- a/docs/03-github/06-deployment/steam.mdx
+++ b/docs/03-github/06-deployment/steam.mdx
@@ -103,10 +103,10 @@ possible to go through the MFA process only once by following these steps:
    should not ask for the MFA code again.
 1. The folder from which you run `steamcmd` (or `~/Library/Application Support/Steam` on macOS)
    will now contain an updated `config/config.vdf` file. Use `cat config/config.vdf | base64 > config_base64.txt`
-   on _Linux_ to encode the file, if you are a on _Windows_ device, use
+   on _Linux_ to encode the file, if you are on a _Windows_ device, use
    `certutil -encode -f .\config\config.vdf tmp.b64 && findstr /v /c:- tmp.b64 > config_base64.txt`.
    Copy the contents of `config_base64.txt` to a GitHub Secret `STEAM_CONFIG_VDF`.
-1. If when running the action you recieve another MFA code via email, run
+1. If when running the action you receive another MFA code via email, run
    `steamcmd +set_steam_guard_code <code>` on your local machine and repeat the `config.vdf`
    encoding and replace secret `STEAM_CONFIG_VDF` with its contents.
 1. You will also need to repeat the process if the action fails with `ERROR (License expired)`

--- a/docs/03-github/06-deployment/steam.mdx
+++ b/docs/03-github/06-deployment/steam.mdx
@@ -106,9 +106,11 @@ possible to go through the MFA process only once by following these steps:
    are a on _Windows_ device, use
    `certutil -encode -f .\config\config.vdf tmp.b64 && findstr /v /c:- tmp.b64 > config_base64.txt`.
    Copy the contents of `config_base64.txt` to a GitHub Secret `STEAM_CONFIG_VDF`.
-1. `If:` when running the action you recieve another MFA code via email, run
+1. If when running the action you recieve another MFA code via email, run
    `steamcmd +set_steam_guard_code <code>` on your local machine and repeat the `config.vdf`
    encoding and replace secret `STEAM_CONFIG_VDF` with its contents.
+1. You will also need to repeat the process if the action fails with `ERROR (License expired)`
+   when logging into Steam.
 
 If your builder account uses MFA through the Steam Guard App, the `steam-deploy` app can use a TOTP
 instead of the above configuration. Generating a TOTP is outside the scope of this guide, as it is


### PR DESCRIPTION
#### Changes

Our action [failed today](https://github.com/anderbellstudios/pop-pixie/actions/runs/16237320674/job/45850089061#step:5:168) with the following message:

```
Logging in user '***' [U:1:1117061749] to Steam Public...ERROR (License expired)
```

I found that refreshing the `config.vdf` file fixed the issue, so this PR updates the docs to let others know how to fix it.

It also looks like the `config/config.vdf` file is placed in `~/Library/Application Support/Steam` on macOS, so I've also added a note about this.

#### Checklist

<!-- please check all items and add your own -->

- [X] Read the contribution [guide](../blob/main/CONTRIBUTING.md) and accept the
      [code](../blob/main/CODE_OF_CONDUCT.md) of conduct
- [X] Readme (updated or not needed)
- [X] Tests (added, updated or not needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded instructions to include the default macOS path for the `config/config.vdf` file.
  * Clarified formatting and steps for encoding on Linux and Windows.
  * Added guidance for handling MFA code requests and updating the GitHub secret.
  * Included steps for addressing `ERROR (License expired)` during Steam login.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->