### PR TITLE
Upgrade upload-artifact to v4

### DIFF
--- a/docs/03-github/01-getting-started.mdx
+++ b/docs/03-github/01-getting-started.mdx
@@ -114,7 +114,7 @@ jobs:
           targetPlatform: WebGL
 
       # Output
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: Build
           path: build
@@ -186,7 +186,7 @@ jobs:
           targetPlatform: WebGL
 
       # Output
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: Build
           path: build
@@ -262,7 +262,7 @@ jobs:
           allowDirtyBuild: true
 
       # Output
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: Build
           path: build
@@ -328,7 +328,7 @@ jobs:
           projectPath: ${{ matrix.projectPath }}
           unityVersion: ${{ matrix.unityVersion }}
           githubToken: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: Test results (all modes)
@@ -345,7 +345,7 @@ jobs:
           unityVersion: ${{ matrix.unityVersion }}
           targetPlatform: ${{ matrix.targetPlatform }}
           customParameters: '-myParameter myValue -myBoolean -ThirdParameter andItsValue'
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: Build
           path: build
@@ -392,7 +392,7 @@ jobs:
           unityVersion: ${{ matrix.unityVersion }}
           targetPlatform: ${{ matrix.targetPlatform }}
           customParameters: '-myParameter myValue -myBoolean -ThirdParameter andItsValue'
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: Build
           path: build
@@ -439,7 +439,7 @@ jobs:
           targetPlatform: ${{ matrix.targetPlatform }}
           customParameters: '-myParameter myValue -myBoolean -ThirdParameter andItsValue'
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: Build
           path: build

--- a/docs/03-github/03-test-runner.mdx
+++ b/docs/03-github/03-test-runner.mdx
@@ -230,7 +230,7 @@ To do this, it is recommended to use the official Github Actions
 By default, Test Runner outputs its results to a folder named `artifacts`.
 
 ```yaml
-- uses: actions/upload-artifact@v3
+- uses: actions/upload-artifact@v4
   if: always()
   with:
     name: Test results
@@ -250,7 +250,7 @@ You can specify a different `artifactsPath` in the test runner and reference thi
 ```
 
 ```yaml
-- uses: actions/upload-artifact@v3
+- uses: actions/upload-artifact@v4
   if: always()
   with:
     name: Test results
@@ -264,7 +264,7 @@ read by the step's `outputs.coveragePath`. These coverage options can be configu
 test and by default will create an XML and HTML web page reports.
 
 ```yaml
-- uses: actions/upload-artifact@v3
+- uses: actions/upload-artifact@v4
   if: always()
   with:
     name: Coverage results
@@ -604,12 +604,12 @@ jobs:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           checkName: ${{ matrix.testMode }} Test Results
           coverageOptions: 'generateAdditionalMetrics;generateHtmlReport;generateBadgeReport;assemblyFilters:+my.assembly.*'
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: Test results for ${{ matrix.testMode }}
           path: ${{ steps.tests.outputs.artifactsPath }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: Coverage results for ${{ matrix.testMode }}
@@ -658,12 +658,12 @@ jobs:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           checkName: ${{ matrix.testMode }} Test Results
           coverageOptions: 'generateAdditionalMetrics;generateHtmlReport;generateBadgeReport;assemblyFilters:+my.assembly.*'
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: Test results for ${{ matrix.testMode }}
           path: ${{ steps.tests.outputs.artifactsPath }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: Coverage results for ${{ matrix.testMode }}

--- a/docs/03-github/04-builder.mdx
+++ b/docs/03-github/04-builder.mdx
@@ -99,7 +99,7 @@ By default, Builder outputs it's builds to a folder named `build`.
 Example:
 
 ```yaml
-- uses: actions/upload-artifact@v3
+- uses: actions/upload-artifact@v4
   with:
     name: Build
     path: build

--- a/docs/03-github/06-deployment/android.mdx
+++ b/docs/03-github/06-deployment/android.mdx
@@ -182,7 +182,7 @@ jobs:
           androidKeyaliasName: ${{ secrets.ANDROID_KEYALIAS_NAME }}
           androidKeyaliasPass: ${{ secrets.ANDROID_KEYALIAS_PASS }}
           androidTargetSdkVersion: AndroidApiLevel33
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: build-Android
           path: build/Android

--- a/docs/03-github/06-deployment/ios.mdx
+++ b/docs/03-github/06-deployment/ios.mdx
@@ -440,7 +440,7 @@ jobs:
         with:
           targetPlatform: iOS
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: build-iOS
           path: build/iOS

--- a/docs/03-github/06-deployment/steam.mdx
+++ b/docs/03-github/06-deployment/steam.mdx
@@ -47,7 +47,7 @@ jobs:
         with:
           targetPlatform: ${{ matrix.targetPlatform }}
           versioning: Semantic
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: Build-${{ matrix.targetPlatform }}
           path: build/${{ matrix.targetPlatform }}

--- a/versioned_docs/version-1/04-github/01-getting-started.mdx
+++ b/versioned_docs/version-1/04-github/01-getting-started.mdx
@@ -98,7 +98,7 @@ jobs:
           targetPlatform: WebGL
 
       # Output
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v4
         with:
           name: Build
           path: build
@@ -153,7 +153,7 @@ jobs:
         with:
           projectPath: ${{ matrix.projectPath }}
           unityVersion: ${{ matrix.unityVersion }}
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v4
         with:
           name: Test results (all modes)
           path: ${{ steps.testRunner.outputs.artifactsPath }}
@@ -163,7 +163,7 @@ jobs:
           unityVersion: ${{ matrix.unityVersion }}
           targetPlatform: ${{ matrix.targetPlatform }}
           customParameters: '-myParameter myValue -myBoolean -ThirdParameter andItsValue'
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v4
         with:
           name: Build
           path: build

--- a/versioned_docs/version-1/04-github/02-activation.mdx
+++ b/versioned_docs/version-1/04-github/02-activation.mdx
@@ -53,7 +53,7 @@ You use the id to **upload the output file** like so:
 ```yaml
 # Upload artifact (Unity_v20XX.X.XXXX.alf)
 - name: Expose as artifact
-  uses: actions/upload-artifact@v1
+  uses: actions/upload-artifact@v4
   with:
     name: ${{ steps.getManualLicenseFile.outputs.filePath }}
     path: ${{ steps.getManualLicenseFile.outputs.filePath }}

--- a/versioned_docs/version-1/04-github/03-test-runner.mdx
+++ b/versioned_docs/version-1/04-github/03-test-runner.mdx
@@ -68,7 +68,7 @@ action.
 By default, Test Runner outputs its results to a folder named `artifacts`.
 
 ```yaml
-- uses: actions/upload-artifact@v1
+- uses: actions/upload-artifact@v4
   with:
     name: Test results
     path: artifacts
@@ -87,7 +87,7 @@ You can specify a different `artifactsPath` in the test runner and reference thi
 ```
 
 ```yaml
-- uses: actions/upload-artifact@v1
+- uses: actions/upload-artifact@v4
   with:
     name: Test results
     path: ${{ steps.myTestStep.outputs.artifactsPath }}
@@ -233,7 +233,7 @@ jobs:
           unityVersion: ${{ matrix.unityVersion }}
           testMode: ${{ matrix.testMode }}
           artifactsPath: ${{ matrix.testMode }}-artifacts
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v4
         with:
           name: Test results for ${{ matrix.testMode }}
           path: ${{ steps.tests.outputs.artifactsPath }}

--- a/versioned_docs/version-1/04-github/04-builder.mdx
+++ b/versioned_docs/version-1/04-github/04-builder.mdx
@@ -72,7 +72,7 @@ By default, Builder outputs it's builds to a folder named `build`.
 Example:
 
 ```yaml
-- uses: actions/upload-artifact@v1
+- uses: actions/upload-artifact@v4
   with:
     name: Build
     path: build
@@ -383,7 +383,7 @@ jobs:
           projectPath: ${{ matrix.projectPath }}
           unityVersion: ${{ matrix.unityVersion }}
           targetPlatform: ${{ matrix.targetPlatform }}
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v4
         with:
           name: Build
           path: build

--- a/versioned_docs/version-1/04-github/06-deployment/android.mdx
+++ b/versioned_docs/version-1/04-github/06-deployment/android.mdx
@@ -74,7 +74,7 @@ BuildForAndroidPlatform:
         androidKeystorePass: ${{ secrets.ANDROID_KEYSTORE_PASS }}
         androidKeyaliasName: ${{ secrets.ANDROID_KEYALIAS_NAME }}
         androidKeyaliasPass: ${{ secrets.ANDROID_KEYALIAS_PASS }}
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: build-Android
         path: build/Android

--- a/versioned_docs/version-1/04-github/06-deployment/ios.mdx
+++ b/versioned_docs/version-1/04-github/06-deployment/ios.mdx
@@ -207,7 +207,7 @@ BuildForiOSPlatform:
     - uses: webbertakken/unity-builder@v1.5
       with:
         targetPlatform: iOS
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: build-iOS
         path: build/iOS

--- a/versioned_docs/version-2/03-github/01-getting-started.mdx
+++ b/versioned_docs/version-2/03-github/01-getting-started.mdx
@@ -107,7 +107,7 @@ jobs:
           targetPlatform: WebGL
 
       # Output
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: Build
           path: build
@@ -177,7 +177,7 @@ jobs:
           targetPlatform: WebGL
 
       # Output
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: Build
           path: build
@@ -241,7 +241,7 @@ jobs:
           projectPath: ${{ matrix.projectPath }}
           unityVersion: ${{ matrix.unityVersion }}
           githubToken: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: Test results (all modes)
@@ -258,7 +258,7 @@ jobs:
           unityVersion: ${{ matrix.unityVersion }}
           targetPlatform: ${{ matrix.targetPlatform }}
           customParameters: '-myParameter myValue -myBoolean -ThirdParameter andItsValue'
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: Build
           path: build
@@ -305,7 +305,7 @@ jobs:
           unityVersion: ${{ matrix.unityVersion }}
           targetPlatform: ${{ matrix.targetPlatform }}
           customParameters: '-myParameter myValue -myBoolean -ThirdParameter andItsValue'
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: Build
           path: build
@@ -352,7 +352,7 @@ jobs:
           targetPlatform: ${{ matrix.targetPlatform }}
           customParameters: '-myParameter myValue -myBoolean -ThirdParameter andItsValue'
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: Build
           path: build

--- a/versioned_docs/version-2/03-github/02-activation.mdx
+++ b/versioned_docs/version-2/03-github/02-activation.mdx
@@ -50,7 +50,7 @@ jobs:
         uses: game-ci/unity-request-activation-file@v2
       # Upload artifact (Unity_v20XX.X.XXXX.alf)
       - name: Expose as artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.getManualLicenseFile.outputs.filePath }}
           path: ${{ steps.getManualLicenseFile.outputs.filePath }}

--- a/versioned_docs/version-2/03-github/03-test-runner.mdx
+++ b/versioned_docs/version-2/03-github/03-test-runner.mdx
@@ -178,7 +178,7 @@ To do this, it is recommended to use the official Github Actions
 By default, Test Runner outputs its results to a folder named `artifacts`.
 
 ```yaml
-- uses: actions/upload-artifact@v2
+- uses: actions/upload-artifact@v4
   if: always()
   with:
     name: Test results
@@ -198,7 +198,7 @@ You can specify a different `artifactsPath` in the test runner and reference thi
 ```
 
 ```yaml
-- uses: actions/upload-artifact@v2
+- uses: actions/upload-artifact@v4
   if: always()
   with:
     name: Test results
@@ -212,7 +212,7 @@ read by the step's `outputs.coveragePath`. These coverage options can be configu
 test and by default will create an XML and HTML web page reports.
 
 ```yaml
-- uses: actions/upload-artifact@v2
+- uses: actions/upload-artifact@v4
   if: always()
   with:
     name: Coverage results
@@ -451,12 +451,12 @@ jobs:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           checkName: ${{ matrix.testMode }} Test Results
           coverageOptions: 'generateAdditionalMetrics;generateHtmlReport;generateBadgeReport;assemblyFilters:+my.assembly.*'
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: Test results for ${{ matrix.testMode }}
           path: ${{ steps.tests.outputs.artifactsPath }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: Coverage results for ${{ matrix.testMode }}
@@ -502,12 +502,12 @@ jobs:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           checkName: ${{ matrix.testMode }} Test Results
           coverageOptions: 'generateAdditionalMetrics;generateHtmlReport;generateBadgeReport;assemblyFilters:+my.assembly.*'
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: Test results for ${{ matrix.testMode }}
           path: ${{ steps.tests.outputs.artifactsPath }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: Coverage results for ${{ matrix.testMode }}

--- a/versioned_docs/version-2/03-github/04-builder.mdx
+++ b/versioned_docs/version-2/03-github/04-builder.mdx
@@ -99,7 +99,7 @@ By default, Builder outputs it's builds to a folder named `build`.
 Example:
 
 ```yaml
-- uses: actions/upload-artifact@v2
+- uses: actions/upload-artifact@v4
   with:
     name: Build
     path: build
@@ -512,7 +512,7 @@ jobs:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
         with:
           targetPlatform: ${{ matrix.targetPlatform }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: Build-${{ matrix.targetPlatform }}
           path: build/${{ matrix.targetPlatform }}

--- a/versioned_docs/version-2/03-github/06-deployment/android.mdx
+++ b/versioned_docs/version-2/03-github/06-deployment/android.mdx
@@ -182,7 +182,7 @@ jobs:
           androidKeyaliasName: ${{ secrets.ANDROID_KEYALIAS_NAME }}
           androidKeyaliasPass: ${{ secrets.ANDROID_KEYALIAS_PASS }}
           androidTargetSdkVersion: AndroidApiLevel31
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: build-Android
           path: build/Android

--- a/versioned_docs/version-2/03-github/06-deployment/ios.mdx
+++ b/versioned_docs/version-2/03-github/06-deployment/ios.mdx
@@ -440,7 +440,7 @@ jobs:
         with:
           targetPlatform: iOS
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: build-iOS
           path: build/iOS

--- a/versioned_docs/version-2/03-github/06-deployment/steam.mdx
+++ b/versioned_docs/version-2/03-github/06-deployment/steam.mdx
@@ -47,7 +47,7 @@ jobs:
         with:
           targetPlatform: ${{ matrix.targetPlatform }}
           versioning: Semantic
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: Build-${{ matrix.targetPlatform }}
           path: build/${{ matrix.targetPlatform }}

--- a/versioned_docs/version-3/03-github/01-getting-started.mdx
+++ b/versioned_docs/version-3/03-github/01-getting-started.mdx
@@ -108,7 +108,7 @@ jobs:
           targetPlatform: WebGL
 
       # Output
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: Build
           path: build
@@ -178,7 +178,7 @@ jobs:
           targetPlatform: WebGL
 
       # Output
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: Build
           path: build
@@ -252,7 +252,7 @@ jobs:
           allowDirtyBuild: true
 
       # Output
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: Build
           path: build
@@ -316,7 +316,7 @@ jobs:
           projectPath: ${{ matrix.projectPath }}
           unityVersion: ${{ matrix.unityVersion }}
           githubToken: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: Test results (all modes)
@@ -333,7 +333,7 @@ jobs:
           unityVersion: ${{ matrix.unityVersion }}
           targetPlatform: ${{ matrix.targetPlatform }}
           customParameters: '-myParameter myValue -myBoolean -ThirdParameter andItsValue'
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: Build
           path: build
@@ -380,7 +380,7 @@ jobs:
           unityVersion: ${{ matrix.unityVersion }}
           targetPlatform: ${{ matrix.targetPlatform }}
           customParameters: '-myParameter myValue -myBoolean -ThirdParameter andItsValue'
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: Build
           path: build
@@ -427,7 +427,7 @@ jobs:
           targetPlatform: ${{ matrix.targetPlatform }}
           customParameters: '-myParameter myValue -myBoolean -ThirdParameter andItsValue'
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: Build
           path: build

--- a/versioned_docs/version-3/03-github/02-activation.mdx
+++ b/versioned_docs/version-3/03-github/02-activation.mdx
@@ -50,7 +50,7 @@ jobs:
         uses: game-ci/unity-request-activation-file@v2
       # Upload artifact (Unity_v20XX.X.XXXX.alf)
       - name: Expose as artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.getManualLicenseFile.outputs.filePath }}
           path: ${{ steps.getManualLicenseFile.outputs.filePath }}

--- a/versioned_docs/version-3/03-github/03-test-runner.mdx
+++ b/versioned_docs/version-3/03-github/03-test-runner.mdx
@@ -178,7 +178,7 @@ To do this, it is recommended to use the official Github Actions
 By default, Test Runner outputs its results to a folder named `artifacts`.
 
 ```yaml
-- uses: actions/upload-artifact@v2
+- uses: actions/upload-artifact@v4
   if: always()
   with:
     name: Test results
@@ -198,7 +198,7 @@ You can specify a different `artifactsPath` in the test runner and reference thi
 ```
 
 ```yaml
-- uses: actions/upload-artifact@v2
+- uses: actions/upload-artifact@v4
   if: always()
   with:
     name: Test results
@@ -212,7 +212,7 @@ read by the step's `outputs.coveragePath`. These coverage options can be configu
 test and by default will create an XML and HTML web page reports.
 
 ```yaml
-- uses: actions/upload-artifact@v2
+- uses: actions/upload-artifact@v4
   if: always()
   with:
     name: Coverage results
@@ -463,12 +463,12 @@ jobs:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           checkName: ${{ matrix.testMode }} Test Results
           coverageOptions: 'generateAdditionalMetrics;generateHtmlReport;generateBadgeReport;assemblyFilters:+my.assembly.*'
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: Test results for ${{ matrix.testMode }}
           path: ${{ steps.tests.outputs.artifactsPath }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: Coverage results for ${{ matrix.testMode }}
@@ -515,12 +515,12 @@ jobs:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           checkName: ${{ matrix.testMode }} Test Results
           coverageOptions: 'generateAdditionalMetrics;generateHtmlReport;generateBadgeReport;assemblyFilters:+my.assembly.*'
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: Test results for ${{ matrix.testMode }}
           path: ${{ steps.tests.outputs.artifactsPath }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: Coverage results for ${{ matrix.testMode }}

--- a/versioned_docs/version-3/03-github/04-builder.mdx
+++ b/versioned_docs/version-3/03-github/04-builder.mdx
@@ -99,7 +99,7 @@ By default, Builder outputs it's builds to a folder named `build`.
 Example:
 
 ```yaml
-- uses: actions/upload-artifact@v2
+- uses: actions/upload-artifact@v4
   with:
     name: Build
     path: build
@@ -618,7 +618,7 @@ jobs:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
         with:
           targetPlatform: ${{ matrix.targetPlatform }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: Build-${{ matrix.targetPlatform }}
           path: build/${{ matrix.targetPlatform }}

--- a/versioned_docs/version-3/03-github/06-deployment/android.mdx
+++ b/versioned_docs/version-3/03-github/06-deployment/android.mdx
@@ -182,7 +182,7 @@ jobs:
           androidKeyaliasName: ${{ secrets.ANDROID_KEYALIAS_NAME }}
           androidKeyaliasPass: ${{ secrets.ANDROID_KEYALIAS_PASS }}
           androidTargetSdkVersion: AndroidApiLevel31
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: build-Android
           path: build/Android

--- a/versioned_docs/version-3/03-github/06-deployment/ios.mdx
+++ b/versioned_docs/version-3/03-github/06-deployment/ios.mdx
@@ -440,7 +440,7 @@ jobs:
         with:
           targetPlatform: iOS
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: build-iOS
           path: build/iOS

--- a/versioned_docs/version-3/03-github/06-deployment/steam.mdx
+++ b/versioned_docs/version-3/03-github/06-deployment/steam.mdx
@@ -47,7 +47,7 @@ jobs:
         with:
           targetPlatform: ${{ matrix.targetPlatform }}
           versioning: Semantic
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: Build-${{ matrix.targetPlatform }}
           path: build/${{ matrix.targetPlatform }}


### PR DESCRIPTION
#### Changes

- Upgrade [actions/upload-artifact](https://github.com/marketplace/actions/upload-a-build-artifact) from v1/v2/v3, which have been deprecated, to v4.

> This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`.
<img width="898" height="203" alt="image" src="https://github.com/user-attachments/assets/ec743c3a-0aee-4ab0-892f-a71b015297c4" />

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../blob/main/CONTRIBUTING.md) and accept the [code](../blob/main/CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
