### PR TITLE
Include xcode/ios platform selection in docs

### DIFF
--- a/docs/03-github/06-deployment/ios.mdx
+++ b/docs/03-github/06-deployment/ios.mdx
@@ -459,6 +459,11 @@ jobs:
           name: build-iOS
           path: build/iOS
 
+      - name: Select Xcode
+        run: |
+          sudo xcode-select --switch /Applications/Xcode_16.4.app
+          xcodebuild -downloadPlatform iOS
+
       - name: Fix File Permissions and Run fastlane
         env:
           APPLE_CONNECT_EMAIL: ${{ secrets.APPLE_CONNECT_EMAIL }}


### PR DESCRIPTION
Include newly required xcode/ios platform selection.

#### Changes

- Update apple deployment docs code sample.

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../blob/main/CONTRIBUTING.md) and accept the
      [code](../blob/main/CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated iOS deployment guidance to include an explicit step for selecting the Xcode 16.4 toolchain and pre-downloading the iOS platform in the App Store release workflow.
  * Clarified step order between artifact download and subsequent build/signing steps to improve reliability and consistency.
  * No changes to app functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->