### PR TITLE
Change customBuildprofile to activeBuildProfile and improve validation

### DIFF
--- a/example/BuildScript.cs
+++ b/example/BuildScript.cs
@@ -99,7 +99,7 @@ namespace UnityBuilderAction
             Dictionary<string, string> options = GetValidatedOptions();
 
             // Load build profile from Assets folder
-            BuildProfile buildProfile = AssetDatabase.LoadAssetAtPath<BuildProfile>(options["customBuildProfile"]);
+            BuildProfile buildProfile = AssetDatabase.LoadAssetAtPath<BuildProfile>(options["activeBuildProfile"]);
 
             // Set it as active
             BuildProfile.SetActiveBuildProfile(buildProfile);
@@ -134,16 +134,18 @@ namespace UnityBuilderAction
                 EditorApplication.Exit(110);
             }
 
-            if (!validatedOptions.TryGetValue("buildTarget", out string buildTarget))
+            if (validatedOptions.TryGetValue("buildTarget", out var buildTarget))
             {
-                Console.WriteLine("Missing argument -buildTarget");
-                EditorApplication.Exit(120);
+                if (!Enum.IsDefined(typeof(BuildTarget), buildTarget ?? string.Empty))
+                {
+                    Console.WriteLine($"{buildTarget} is not a defined {nameof(BuildTarget)}");
+                    EditorApplication.Exit(121);
+                }
             }
-
-            if (!Enum.IsDefined(typeof(BuildTarget), buildTarget ?? string.Empty))
+            else if (!validatedOptions.TryGetValue("activeBuildProfile", out string _))
             {
-                Console.WriteLine($"{buildTarget} is not a defined {nameof(BuildTarget)}");
-                EditorApplication.Exit(121);
+                Console.WriteLine("Missing argument -buildTarget or -activeBuildProfile");
+                EditorApplication.Exit(120);
             }
 
             if (!validatedOptions.TryGetValue("customBuildPath", out string _))


### PR DESCRIPTION
Update to support https://github.com/game-ci/unity-builder/pull/738

#### Changes

- Change customBuildprofile to activeBuildProfile and improve validation

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../blob/main/CONTRIBUTING.md) and accept the
      [code](../blob/main/CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.
- Bug Fixes
  - Stricter validation for build targets: invalid values now fail with a clear message and exit code 121.
  - Unified handling when neither a build target nor an active build profile is provided, with a clear error and exit code 120.
- Chores
  - Switched profile loading to use the active build profile key.
  - Standardized error messages and control flow during build option validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->