### PR TITLE
docs(secrets): premade secret sources documentation

### DIFF
--- a/docs/03-github-orchestrator/06-advanced-topics/06-secrets.mdx
+++ b/docs/03-github-orchestrator/06-advanced-topics/06-secrets.mdx
@@ -17,6 +17,8 @@ approach — it replaces the older `inputPullCommand` mechanism with a cleaner A
 | AWS Parameter Store | `aws-parameter-store` | `aws` CLI |
 | GCP Secret Manager | `gcp-secret-manager` | `gcloud` CLI |
 | Azure Key Vault | `azure-key-vault` | `az` CLI + `AZURE_VAULT_NAME` env var |
+| HashiCorp Vault (KV v2) | `hashicorp-vault` or `vault` | `vault` CLI + `VAULT_ADDR` env var |
+| HashiCorp Vault (KV v1) | `hashicorp-vault-kv1` | `vault` CLI + `VAULT_ADDR` env var |
 | Environment Variables | `env` | None |
 
 ### Usage
@@ -84,6 +86,43 @@ env:
   pullInputList: UNITY_LICENSE,UNITY_SERIAL
   secretSource: azure-key-vault
   AZURE_VAULT_NAME: my-game-ci-vault
+```
+
+### HashiCorp Vault
+
+Fetches secrets using the `vault` CLI. Requires `VAULT_ADDR` to be set. Authentication is
+handled by standard Vault environment variables (`VAULT_TOKEN`, AppRole, Kubernetes auth, etc.).
+
+Use `hashicorp-vault` (or the `vault` shorthand) for **KV v2** secrets engines, or
+`hashicorp-vault-kv1` for **KV v1**.
+
+```yaml
+env:
+  pullInputList: UNITY_LICENSE,UNITY_SERIAL
+  secretSource: vault
+  VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+  VAULT_TOKEN: ${{ secrets.VAULT_TOKEN }}
+```
+
+By default, secrets are read from the `secret` mount path. Override with `VAULT_MOUNT`:
+
+```yaml
+env:
+  pullInputList: UNITY_LICENSE,UNITY_SERIAL
+  secretSource: hashicorp-vault
+  VAULT_ADDR: https://vault.example.com
+  VAULT_TOKEN: ${{ secrets.VAULT_TOKEN }}
+  VAULT_MOUNT: game-ci
+```
+
+For **KV v1** engines:
+
+```yaml
+env:
+  pullInputList: UNITY_LICENSE,UNITY_SERIAL
+  secretSource: hashicorp-vault-kv1
+  VAULT_ADDR: https://vault.example.com
+  VAULT_TOKEN: ${{ secrets.VAULT_TOKEN }}
 ```
 
 ### Environment Variables


### PR DESCRIPTION
## Summary

Expand the Secrets documentation page with comprehensive coverage of the new `secretSource` input.

- Premade source documentation (AWS Secrets Manager, AWS Parameter Store, GCP Secret Manager, Azure Key Vault, env)
- Custom command syntax with `{0}` placeholder
- YAML file definitions for custom sources
- Migration notes from legacy `inputPullCommand`
- Provider-specific secret handling (K8s, AWS, Local Docker)

Companion to game-ci/unity-builder#787

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>