### PR TITLE
docs: engine plugin system for game-engine agnostic orchestration

### DIFF
--- a/docs/03-github-orchestrator/01-introduction.mdx
+++ b/docs/03-github-orchestrator/01-introduction.mdx
@@ -3,11 +3,13 @@
 ## What Does Orchestrator Do?
 
 **Orchestrator is an advanced build layer on top of
-[Game CI unity-builder](https://github.com/game-ci/unity-builder).** It dispatches Unity builds to
-cloud infrastructure, self-hosted runners, or local Docker containers instead of running them
-directly on your CI runner. Start jobs from GitHub Actions, the command line, or any CI system.
-Orchestrator provisions the environment, syncs your project, runs the build, and streams results
-back.
+[Game CI unity-builder](https://github.com/game-ci/unity-builder).** It dispatches builds to cloud
+infrastructure, self-hosted runners, or local Docker containers instead of running them directly on
+your CI runner. While Unity is the built-in default, Orchestrator is engine agnostic — Godot,
+Unreal, and custom engines can plug in via the
+[engine plugin system](advanced-topics/engine-plugins). Start jobs from GitHub Actions, the command
+line, or any CI system. Orchestrator provisions the environment, syncs your project, runs the build,
+and streams results back.
 
 ```mermaid
 flowchart LR
@@ -46,6 +48,7 @@ failover, and multi-provider load balancing.
 | **Automatic caching**      | Unity Library, LFS objects, and build output cached to S3 or 70+ backends via rclone                                             |
 | **Provider failover**      | Automatically route to a fallback provider when the primary is unavailable or overloaded                                         |
 | **Extensible**             | Run [custom hooks](advanced-topics/hooks/container-hooks), middleware, or your own [provider plugin](providers/custom-providers) |
+| **Engine agnostic**        | Built-in Unity support with a plugin system for [other engines](advanced-topics/engine-plugins) (Godot, Unreal, custom)          |
 | **Self-hosted friendly**   | Complements self-hosted runners with automatic fallback, load balancing, and runner availability checks                          |
 
 ## When You Might Not Need It

--- a/docs/03-github-orchestrator/05-api-reference.mdx
+++ b/docs/03-github-orchestrator/05-api-reference.mdx
@@ -39,6 +39,13 @@ Set the mode to control what Orchestrator does. Default: `cli-build`.
 | `orchestratorBranch`   | `main`                  | Release branch of Orchestrator for remote containers. Use `orchestrator-develop` for latest development builds.                                                                   |
 | `orchestratorRepoName` | `game-ci/unity-builder` | Repository for Orchestrator source. Override to use a fork for testing or custom builds.                                                                                          |
 
+### Engine
+
+| Parameter      | Default | Description                                                                                                                                                |
+| -------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `engine`       | `unity` | Game engine name. Built-in: `unity`. Other engines require `enginePlugin`.                                                                                 |
+| `enginePlugin` | -       | Engine plugin source. NPM package, `cli:<path>`, or `docker:<image>`. See [Engine Plugins](advanced-topics/engine-plugins) for details and source formats. |
+
 ### Git Synchronization
 
 | Parameter           | Default  | Description                                                         |

--- a/docs/03-github-orchestrator/07-advanced-topics/01-caching.mdx
+++ b/docs/03-github-orchestrator/07-advanced-topics/01-caching.mdx
@@ -16,8 +16,9 @@ flowchart LR
 
 ## Standard Caching
 
-Caches only the Unity **Library** folder and **LFS** files between builds. Uses less storage but
-requires re-importing unchanged assets.
+Caches the engine's asset folders and **LFS** files between builds. For Unity this is the `Library`
+folder. For other engines, the cached folders are defined by the [engine plugin](engine-plugins)
+(e.g. `.godot/imported` for Godot). Uses less storage but requires re-importing unchanged assets.
 
 - ✅ Minimum storage cost
 - ✅ Best for smaller projects

--- a/docs/03-github-orchestrator/07-advanced-topics/18-engine-plugins.mdx
+++ b/docs/03-github-orchestrator/07-advanced-topics/18-engine-plugins.mdx
@@ -1,0 +1,203 @@
+---
+sidebar_position: 18
+---
+
+# Engine Plugins
+
+Orchestrator is game-engine agnostic. While Unity is the built-in default, you can plug in any game
+engine — Godot, Unreal, a custom engine, or anything else — without forking the orchestrator.
+
+An **engine plugin** tells the orchestrator how to handle engine-specific concerns like cache
+folders and container lifecycle hooks. Everything else (provisioning, git sync, logging, hooks,
+secrets) works the same regardless of engine.
+
+## How It Works
+
+The orchestrator only needs to know two things about your engine:
+
+1. **Which folders to cache** between builds (e.g. `Library` for Unity, `.godot/imported` for Godot)
+2. **What to run on container shutdown** (e.g. Unity needs to return its license)
+
+That's the entire `EnginePlugin` interface:
+
+```typescript
+interface EnginePlugin {
+  name: string; // 'unity', 'godot', 'unreal', etc.
+  cacheFolders: string[]; // folders to cache, relative to project root
+  preStopCommand?: string; // shell command for container shutdown (optional)
+}
+```
+
+## Built-in: Unity
+
+Unity is the default engine plugin. When you don't specify `--engine` or `--engine-plugin`, the
+orchestrator behaves exactly as it always has — caching the `Library` folder and returning the Unity
+license on container shutdown.
+
+No configuration needed. Existing workflows are unchanged.
+
+## Using a Different Engine
+
+Set `engine` and `enginePlugin` to load a community or custom engine plugin:
+
+```yaml
+# GitHub Actions
+- uses: game-ci/unity-builder@v4
+  with:
+    engine: godot
+    enginePlugin: '@game-ci/godot-engine'
+    targetPlatform: StandaloneLinux64
+```
+
+```bash
+# CLI
+game-ci build \
+  --engine godot \
+  --engine-plugin @game-ci/godot-engine \
+  --target-platform linux
+```
+
+## Plugin Sources
+
+Engine plugins can be loaded from three sources:
+
+| Source             | Format                     | Example                                   |
+| ------------------ | -------------------------- | ----------------------------------------- |
+| **NPM module**     | Package name or local path | `@game-ci/godot-engine`, `./my-plugin.js` |
+| **CLI executable** | `cli:<path>`               | `cli:/usr/local/bin/my-engine-plugin`     |
+| **Docker image**   | `docker:<image>`           | `docker:gameci/godot-engine-plugin`       |
+
+When no prefix is specified, the plugin is loaded as an NPM module.
+
+### NPM Module
+
+The simplest way to distribute an engine plugin. Publish an NPM package that exports an
+`EnginePlugin` object:
+
+```typescript
+// index.ts
+export default {
+  name: 'godot',
+  cacheFolders: ['.godot/imported', '.godot/shader_cache'],
+};
+```
+
+Supports default export, named `plugin` export, or `module.exports`:
+
+```javascript
+// CommonJS
+module.exports = {
+  name: 'godot',
+  cacheFolders: ['.godot/imported'],
+};
+```
+
+Install the package in your project, then reference it:
+
+```yaml
+enginePlugin: '@your-org/godot-engine'
+```
+
+Or point to a local file during development:
+
+```yaml
+enginePlugin: './my-engine-plugin.js'
+```
+
+### CLI Executable
+
+For plugins written in any language (Go, Python, Rust, shell, etc.). The executable receives a
+`get-engine-config` argument and must print a JSON config on stdout:
+
+```bash
+$ my-engine-plugin get-engine-config
+{"name": "godot", "cacheFolders": [".godot/imported"], "preStopCommand": ""}
+```
+
+Reference it with the `cli:` prefix:
+
+```yaml
+enginePlugin: 'cli:/usr/local/bin/my-engine-plugin'
+```
+
+### Docker Image
+
+For containerized plugin distribution. The image is run with
+`docker run --rm <image> get-engine-config` and must print JSON config on stdout:
+
+```dockerfile
+FROM alpine
+COPY config.json /config.json
+ENTRYPOINT ["sh", "-c", "cat /config.json"]
+```
+
+Reference it with the `docker:` prefix:
+
+```yaml
+enginePlugin: 'docker:your-org/godot-engine-plugin'
+```
+
+## Writing an Engine Plugin
+
+To create a plugin for your engine, you need to answer two questions:
+
+1. **What folders should be cached?** These are directories that take a long time to regenerate but
+   don't change between builds. For Unity this is `Library`, for Godot it's `.godot/imported`.
+
+2. **Does your engine need cleanup on container shutdown?** Unity needs to return its license. Most
+   engines don't need anything here — just omit `preStopCommand`.
+
+### Example: Minimal Godot Plugin
+
+```typescript
+export default {
+  name: 'godot',
+  cacheFolders: ['.godot/imported', '.godot/shader_cache'],
+};
+```
+
+### Example: Engine with License Cleanup
+
+```typescript
+export default {
+  name: 'my-engine',
+  cacheFolders: ['Cache', 'Intermediate'],
+  preStopCommand: '/opt/my-engine/return-license.sh',
+};
+```
+
+## What the Plugin Controls
+
+The engine plugin **only** controls orchestrator-level behavior that varies by engine:
+
+| Behavior               | Controlled by plugin | Notes                                                 |
+| ---------------------- | -------------------- | ----------------------------------------------------- |
+| Cache folders          | Yes                  | Which project folders to persist between builds       |
+| Container preStop hook | Yes                  | Shell command run on K8s container shutdown           |
+| Docker image           | No                   | Passed by the caller via `customImage` or `baseImage` |
+| Build scripts          | No                   | Owned by the builder action (e.g. unity-builder)      |
+| Version detection      | No                   | Handled by the caller or builder action               |
+| License activation     | No                   | Handled by the builder action's entrypoint            |
+
+This keeps plugins minimal. A complete engine plugin is typically 3-5 lines of config.
+
+## Programmatic Usage
+
+If you're building a custom integration, you can use the engine plugin API directly:
+
+```typescript
+import { setEngine, getEngine, loadEngineFromModule } from '@game-ci/orchestrator';
+
+// Load from an NPM package
+const plugin = loadEngineFromModule('@game-ci/godot-engine');
+setEngine(plugin);
+
+// Or set inline
+setEngine({
+  name: 'godot',
+  cacheFolders: ['.godot/imported'],
+});
+
+// Check current engine
+console.log(getEngine().name); // 'godot'
+```

--- a/docs/03-github-orchestrator/08-cli/02-build-command.mdx
+++ b/docs/03-github-orchestrator/08-cli/02-build-command.mdx
@@ -46,6 +46,24 @@ game-ci build [options]
 | `--skip-activation`        | `false`   | Skip Unity license activation/deactivation                                                          |
 | `--unity-licensing-server` | _(empty)_ | Unity floating license server address                                                               |
 
+## Engine Options
+
+| Flag              | Default   | Description                                                                                                                    |
+| ----------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `--engine`        | `unity`   | Game engine name (`unity`, `godot`, `unreal`, etc.)                                                                            |
+| `--engine-plugin` | _(empty)_ | Engine plugin source: NPM package, `cli:<path>`, or `docker:<image>`. See [Engine Plugins](../advanced-topics/engine-plugins). |
+
+### Non-Unity Engine Example
+
+```bash
+game-ci build \
+  --engine godot \
+  --engine-plugin @game-ci/godot-engine \
+  --target-platform linux \
+  --custom-image my-godot-image:4.2 \
+  --provider-strategy aws
+```
+
 ## Custom Build Parameters
 
 Pass arbitrary parameters to the Unity build process:


### PR DESCRIPTION
## Summary

Documents the new engine plugin system from [game-ci/orchestrator#4](https://github.com/game-ci/orchestrator/pull/4) that makes the orchestrator game-engine agnostic.

- **New page**: [Advanced Topics > Engine Plugins](docs/03-github-orchestrator/07-advanced-topics/18-engine-plugins.mdx) — full guide covering the EnginePlugin interface, plugin sources (npm module, CLI executable, Docker image), and how to author plugins
- **Updated introduction** to mention engine agnosticism as a key benefit
- **Updated caching page** to reference engine-aware cache folders instead of hardcoded "Library"
- **Added `engine` and `enginePlugin`** to API reference parameters
- **Added `--engine` and `--engine-plugin`** to CLI build command docs

## Changes

| File | Change |
|------|--------|
| `01-introduction.mdx` | Mention engine agnosticism in intro paragraph and benefits table |
| `05-api-reference.mdx` | New Engine parameters section |
| `07-advanced-topics/01-caching.mdx` | Reference engine plugin for cache folders |
| `07-advanced-topics/18-engine-plugins.mdx` | New full page |
| `08-cli/02-build-command.mdx` | New Engine Options section with example |

🤖 Generated with [Claude Code](https://claude.com/claude-code)