### PR TITLE
Fix React error #31 on admin rebuild image button

### DIFF
--- a/src/components/docs/versions/docker-image-link-or-retry-button.tsx
+++ b/src/components/docs/versions/docker-image-link-or-retry-button.tsx
@@ -51,7 +51,7 @@ const DockerImageLinkOrRetryButton = ({ record }: Props) => {
       setRetryRequested(true);
       await notify.promise(retryBuild(), {
         loading: <Spinner type="spin" />,
-        success: (message) => message,
+        success: (response) => response.message,
         error: (error) => error.message,
       });
     } catch {


### PR DESCRIPTION
## Summary
- The admin "retry build" button on the [Docker versions page](https://game.ci/docs/docker/versions/) crashes with **React error #31** ("Objects are not valid as a React child")
- The `retryBuild` API returns `{ message, description }`, but the toast success handler was passing the entire object to react-hot-toast instead of extracting the string
- Fixed by changing `(message) => message` to `(response) => response.message`

## Test plan
- [x] Log in as admin and navigate to Docker versions page
- [x] Click the retry/rebuild button on a failed build
- [x] Verify the success toast renders the message string instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed success notification messaging in the Docker image feature to correctly display server response information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->