### PR TITLE
Add bulk 'Reset all failed builds' admin button to versions page

### DIFF
--- a/src/components/docs/versions/image-versions.tsx
+++ b/src/components/docs/versions/image-versions.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import SignInSignOutButton from '@site/src/components/auth/sign-in-sign-out-button';
 import CleanUpStuckBuildsButton from './clean-up-stuck-builds-button';
+import ResetAllFailedBuildsButton from './reset-all-failed-builds-button';
 import UnityVersions from './unity-versions';
 import styles from './unity-version.module.scss';
 
@@ -30,6 +31,7 @@ const ImageVersions = ({ versions }: Props) => {
           })}
         </select>
         <span style={{ float: 'right', display: 'flex', alignItems: 'center', gap: 8 }}>
+          <ResetAllFailedBuildsButton />
           <CleanUpStuckBuildsButton />
           <SignInSignOutButton />
         </span>

--- a/src/components/docs/versions/reset-all-failed-builds-button.tsx
+++ b/src/components/docs/versions/reset-all-failed-builds-button.tsx
@@ -1,0 +1,57 @@
+import React, { useState } from 'react';
+import { MdRestartAlt } from 'react-icons/md';
+import { SimpleAuthCheck } from '@site/src/components/auth/safe-auth-check';
+import { useAuthenticatedEndpoint } from '@site/src/core/hooks/use-authenticated-endpoint';
+import { useNotification } from '@site/src/core/hooks/use-notification';
+import Spinner from '@site/src/components/molecules/spinner';
+import Tooltip from '@site/src/components/molecules/tooltip/tooltip';
+
+const ResetAllFailedBuildsButton = () => {
+  const [running, setRunning] = useState(false);
+  const notify = useNotification();
+  const resetAll = useAuthenticatedEndpoint('resetFailedBuilds', {});
+
+  const onClick = async () => {
+    try {
+      setRunning(true);
+      await notify.promise(resetAll(), {
+        loading: <Spinner type="spin" />,
+        success: (response) => {
+          const results = response.results || [];
+          return results.length > 0 ? results.join('\n') : response.message;
+        },
+        error: (error) => error.message || 'Reset failed',
+      });
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  return (
+    <SimpleAuthCheck fallback={<span />} requiredClaims={{ admin: true }}>
+      <Tooltip content="Reset failure counts on all builds stuck at max retries (15+) so the Ingeminator retries them">
+        <button
+          type="button"
+          onClick={onClick}
+          disabled={running}
+          style={{
+            padding: '4px 12px',
+            border: '1px solid #ccc',
+            borderRadius: 4,
+            cursor: running ? 'wait' : 'pointer',
+            background: 'transparent',
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 6,
+            fontSize: '0.85em',
+          }}
+        >
+          <MdRestartAlt color={running ? 'orange' : 'inherit'} />
+          Reset all failed builds
+        </button>
+      </Tooltip>
+    </SimpleAuthCheck>
+  );
+};
+
+export default ResetAllFailedBuildsButton;


### PR DESCRIPTION
## Summary

- Adds a **"Reset all failed builds"** button to the versions page header, next to the existing "Clean up stuck builds" button
- Calls the `resetFailedBuilds` endpoint (deployed in game-ci/versioning-backend#85) with an empty payload to bulk-reset all builds stuck at max retries (failureCount >= 15)
- Admin-only (requires `admin: true` claim), follows the exact same pattern as `CleanUpStuckBuildsButton`

This completes the admin UI toolchain for managing stuck builds:
| Control | Scope | Location |
|---------|-------|----------|
| Reset button (per-build) | Single build | Build row (#548) |
| **Reset all failed builds** | All maxed-out builds | **Page header (this PR)** |
| Clean up stuck builds | Builds stuck in "started" | Page header (existing) |
| Retry button (per-build) | Single build | Build row (existing) |

## Test plan
- [ ] Sign in as admin on versions page
- [ ] Verify "Reset all failed builds" button appears in header next to "Clean up stuck builds"
- [ ] Click button, confirm it calls `resetFailedBuilds` endpoint and shows toast notification
- [ ] Verify non-admin users do not see the button

🤖 Generated with [Claude Code](https://claude.com/claude-code)