### PR TITLE
Show server error detail in endpoint failure messages

### DIFF
--- a/src/core/hooks/use-authenticated-endpoint.tsx
+++ b/src/core/hooks/use-authenticated-endpoint.tsx
@@ -18,7 +18,8 @@ export function useAuthenticatedEndpoint(endpoint: string, payload: { [key: stri
 
     const body = await response.json();
     if (!response.ok) {
-      throw new Error(body.message || `Request failed (${response.status})`);
+      const detail = body.error ? `${body.message}: ${body.error}` : body.message;
+      throw new Error(detail || `Request failed (${response.status})`);
     }
     return body;
   };


### PR DESCRIPTION
## Summary
- The `useAuthenticatedEndpoint` hook was only showing `body.message` from error responses, discarding the actual error detail in `body.error`
- Now displays both: e.g. "Internal error during reset: <actual error>" instead of just "Internal error during reset"
- Helps diagnose the Reset All Failed Builds 500 error

## Test plan
- [ ] Click Reset All Failed Builds as admin
- [ ] If it fails, verify the toast now shows the actual server error message instead of the generic one

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error message display for API request failures with more comprehensive details when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->