### PR TITLE
Add admin dashboard, bulk actions, filters, and timeline

### DIFF
--- a/src/components/docs/versions/build-status-dashboard.tsx
+++ b/src/components/docs/versions/build-status-dashboard.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { useFirestore, useFirestoreCollectionData } from 'reactfire';
+import Spinner from '@site/src/components/molecules/spinner';
+
+interface Props {
+  selectedRepoVersion: string | undefined;
+}
+
+const BuildStatusDashboard = ({ selectedRepoVersion }: Props) => {
+  if (!selectedRepoVersion) return null;
+
+  const ciBuilds = useFirestore()
+    .collection('ciBuilds')
+    .where('buildInfo.repoVersion', '==', selectedRepoVersion);
+
+  const { status, data } = useFirestoreCollectionData<{ [key: string]: any }>(ciBuilds);
+
+  if (status === 'loading') {
+    return (
+      <div style={{ padding: '8px 0', display: 'flex', alignItems: 'center', gap: 8 }}>
+        <Spinner type="slow" /> Loading build stats...
+      </div>
+    );
+  }
+
+  const builds = data || [];
+  const started = builds.filter((b) => b.status === 'started').length;
+  const failed = builds.filter((b) => b.status === 'failed').length;
+  const published = builds.filter((b) => b.status === 'published').length;
+  const maxedOut = builds.filter(
+    (b) => b.status === 'failed' && (b.meta?.failureCount || 0) >= 15,
+  ).length;
+  const total = builds.length;
+
+  const statStyle = (color: string): React.CSSProperties => ({
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: 6,
+    padding: '4px 12px',
+    borderRadius: 6,
+    border: `1px solid ${color}33`,
+    background: `${color}11`,
+    fontSize: '0.85em',
+    fontWeight: 500,
+  });
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexWrap: 'wrap',
+        gap: 8,
+        padding: '12px 0',
+        alignItems: 'center',
+      }}
+    >
+      <span style={statStyle('#666')}>
+        Total: <strong>{total}</strong>
+      </span>
+      <span style={statStyle('#22c55e')}>
+        Published: <strong>{published}</strong>
+      </span>
+      <span style={statStyle('#3b82f6')}>
+        In progress: <strong>{started}</strong>
+      </span>
+      <span style={statStyle('#ef4444')}>
+        Failed: <strong>{failed}</strong>
+      </span>
+      {maxedOut > 0 && (
+        <span style={statStyle('#b45309')}>
+          Stuck (15+): <strong>{maxedOut}</strong>
+        </span>
+      )}
+      <span
+        style={{
+          marginLeft: 'auto',
+          fontSize: '0.75em',
+          opacity: 0.6,
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 4,
+        }}
+      >
+        <span
+          style={{
+            width: 6,
+            height: 6,
+            borderRadius: '50%',
+            background: '#22c55e',
+            display: 'inline-block',
+            animation: 'pulse 2s infinite',
+          }}
+        />
+        Live
+      </span>
+    </div>
+  );
+};
+
+export default BuildStatusDashboard;

--- a/src/components/docs/versions/build-status-dashboard.tsx
+++ b/src/components/docs/versions/build-status-dashboard.tsx
@@ -7,13 +7,14 @@ interface Props {
 }
 
 const BuildStatusDashboard = ({ selectedRepoVersion }: Props) => {
-  if (!selectedRepoVersion) return null;
-
-  const ciBuilds = useFirestore()
+  const firestore = useFirestore();
+  const ciBuilds = firestore
     .collection('ciBuilds')
-    .where('buildInfo.repoVersion', '==', selectedRepoVersion);
+    .where('buildInfo.repoVersion', '==', selectedRepoVersion || '__none__');
 
   const { status, data } = useFirestoreCollectionData<{ [key: string]: any }>(ciBuilds);
+
+  if (!selectedRepoVersion) return null;
 
   if (status === 'loading') {
     return (
@@ -45,55 +46,58 @@ const BuildStatusDashboard = ({ selectedRepoVersion }: Props) => {
   });
 
   return (
-    <div
-      style={{
-        display: 'flex',
-        flexWrap: 'wrap',
-        gap: 8,
-        padding: '12px 0',
-        alignItems: 'center',
-      }}
-    >
-      <span style={statStyle('#666')}>
-        Total: <strong>{total}</strong>
-      </span>
-      <span style={statStyle('#22c55e')}>
-        Published: <strong>{published}</strong>
-      </span>
-      <span style={statStyle('#3b82f6')}>
-        In progress: <strong>{started}</strong>
-      </span>
-      <span style={statStyle('#ef4444')}>
-        Failed: <strong>{failed}</strong>
-      </span>
-      {maxedOut > 0 && (
-        <span style={statStyle('#b45309')}>
-          Stuck (15+): <strong>{maxedOut}</strong>
-        </span>
-      )}
-      <span
+    <>
+      <style>{`@keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }`}</style>
+      <div
         style={{
-          marginLeft: 'auto',
-          fontSize: '0.75em',
-          opacity: 0.6,
-          display: 'inline-flex',
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: 8,
+          padding: '12px 0',
           alignItems: 'center',
-          gap: 4,
         }}
       >
+        <span style={statStyle('#666')}>
+          Total: <strong>{total}</strong>
+        </span>
+        <span style={statStyle('#22c55e')}>
+          Published: <strong>{published}</strong>
+        </span>
+        <span style={statStyle('#3b82f6')}>
+          In progress: <strong>{started}</strong>
+        </span>
+        <span style={statStyle('#ef4444')}>
+          Failed: <strong>{failed}</strong>
+        </span>
+        {maxedOut > 0 && (
+          <span style={statStyle('#b45309')}>
+            Stuck (15+): <strong>{maxedOut}</strong>
+          </span>
+        )}
         <span
           style={{
-            width: 6,
-            height: 6,
-            borderRadius: '50%',
-            background: '#22c55e',
-            display: 'inline-block',
-            animation: 'pulse 2s infinite',
+            marginLeft: 'auto',
+            fontSize: '0.75em',
+            opacity: 0.6,
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 4,
           }}
-        />
-        Live
-      </span>
-    </div>
+        >
+          <span
+            style={{
+              width: 6,
+              height: 6,
+              borderRadius: '50%',
+              background: '#22c55e',
+              display: 'inline-block',
+              animation: 'pulse 2s ease-in-out infinite',
+            }}
+          />
+          Live
+        </span>
+      </div>
+    </>
   );
 };
 

--- a/src/components/docs/versions/builds/build-failure-details.tsx
+++ b/src/components/docs/versions/builds/build-failure-details.tsx
@@ -18,6 +18,9 @@ const BuildFailureDetails = ({
 }: Props) => {
   const { editorVersion, baseOs, targetPlatform } = ciBuild.buildInfo;
   const { major, minor, patch } = repoVersionInfo;
+  const buildRepoVersion = ciBuild.buildInfo.repoVersion;
+  const jobRepoVersion = repoVersionInfo.version;
+  const hasRepoVersionDrift = jobRepoVersion !== buildRepoVersion;
 
   const reducer = (state, action) => {
     const { tag, value } = action;
@@ -72,6 +75,22 @@ docker build . \\
 
   return (
     <div {...rest}>
+      <h4>Operational diagnostics</h4>
+      <CodeBlock language="json">
+        {JSON.stringify(
+          {
+            jobRepoVersion,
+            buildRepoVersion,
+            hasRepoVersionDrift,
+            recommendedAction: hasRepoVersionDrift
+              ? 'Do not keep retrying this build as-is. Inspect stale older-version jobs and supersede them before retrying current jobs.'
+              : 'Retry/reset/cleanup actions on this page are safe to use if the failure is still active.',
+          },
+          null,
+          2,
+        )}
+      </CodeBlock>
+      <br />
       <h4>CI Job identification</h4>
       <CodeBlock language="json">{JSON.stringify(ciJob, null, 2)}</CodeBlock>
       <br />

--- a/src/components/docs/versions/builds/build-failure-details.tsx
+++ b/src/components/docs/versions/builds/build-failure-details.tsx
@@ -16,10 +16,13 @@ const BuildFailureDetails = ({
   ciBuild,
   ...rest
 }: Props) => {
-  const { editorVersion, baseOs, targetPlatform } = ciBuild.buildInfo;
-  const { major, minor, patch } = repoVersionInfo;
-  const buildRepoVersion = ciBuild.buildInfo.repoVersion;
-  const jobRepoVersion = repoVersionInfo.version;
+  const {
+    editorVersion,
+    baseOs,
+    targetPlatform,
+    repoVersion: buildRepoVersion,
+  } = ciBuild.buildInfo;
+  const { major, minor, patch, version: jobRepoVersion } = repoVersionInfo;
   const hasRepoVersionDrift = jobRepoVersion !== buildRepoVersion;
 
   const reducer = (state, action) => {

--- a/src/components/docs/versions/builds/build-row.tsx
+++ b/src/components/docs/versions/builds/build-row.tsx
@@ -39,27 +39,28 @@ export default function BuildRow({ children, build, selected, onToggleSelect }: 
   const [expanded, setExpanded] = useState(false);
   const [toolbarContent, setToolbarContent] = useState('Click to copy');
 
-  const MapBuildStatusToElement = (status: string) => {
-    const icon = mapBuildStatusToIcon[status];
+  const { buildId, status, failure, meta: rawMeta, addedDate, imageType, buildInfo } = build;
 
-    switch (status) {
+  const MapBuildStatusToElement = (buildStatus: string) => {
+    const icon = mapBuildStatusToIcon[buildStatus];
+
+    switch (buildStatus) {
       case 'started':
         return <Spinner type="slow" />;
       case 'failed': {
-        const count = build.meta?.failureCount || 0;
+        const count = rawMeta?.failureCount || 0;
         const label = count >= 15 ? `${icon} (${count}/15)` : icon;
-        return <Tooltip content={build.failure?.reason}>{label}</Tooltip>;
+        return <Tooltip content={failure?.reason}>{label}</Tooltip>;
       }
       case 'published':
         return icon;
       default:
-        return status;
+        return buildStatus;
     }
   };
 
   // Build timeline data
-  const meta = (build.meta || {}) as { [key: string]: any };
-  const { addedDate } = build;
+  const meta = (rawMeta || {}) as { [key: string]: any };
   const { lastBuildStart, lastBuildFailure, publishedDate, failureCount = 0 } = meta;
 
   const timelineItems: { label: string; time: string; color: string }[] = [];
@@ -87,14 +88,17 @@ export default function BuildRow({ children, build, selected, onToggleSelect }: 
   return (
     <>
       <tr className={styles.tableRow}>
-        <SimpleAuthCheck fallback={<td style={{ width: 30 }} />} requiredClaims={{ admin: true }}>
+        <SimpleAuthCheck
+          fallback={<td aria-label="spacer" style={{ width: 30 }} />}
+          requiredClaims={{ admin: true }}
+        >
           <td style={{ width: 30, textAlign: 'center' }}>
-            {build.status === 'failed' && (
+            {status === 'failed' && (
               <input
                 type="checkbox"
                 checked={selected}
                 onChange={onToggleSelect}
-                aria-label={`Select build ${build.buildId}`}
+                aria-label={`Select build ${buildId}`}
                 style={{ cursor: 'pointer' }}
               />
             )}
@@ -103,16 +107,17 @@ export default function BuildRow({ children, build, selected, onToggleSelect }: 
         <td
           onClick={() => setExpanded(!expanded)}
           className="text-center select-none cursor-pointer text-2xl"
+          aria-label={expanded ? 'Collapse build details' : 'Expand build details'}
         >
           {expanded ? '-' : '+'}
         </td>
-        <td className="text-center">{MapBuildStatusToElement(build.status)}</td>
+        <td className="text-center">{MapBuildStatusToElement(status)}</td>
         <td>
           <span>
             <Tooltip content={toolbarContent}>
               <button
                 onClick={() => {
-                  CopyToClipboard(build.buildId);
+                  CopyToClipboard(buildId);
                   setToolbarContent('Copied to clipboard!');
                 }}
                 onMouseLeave={() => {
@@ -120,24 +125,24 @@ export default function BuildRow({ children, build, selected, onToggleSelect }: 
                 }}
                 type="button"
               >
-                {build.buildId}
+                {buildId}
               </button>
             </Tooltip>
             <DockerImageLinkOrRetryButton record={build} />
           </span>
         </td>
-        <td>{build.imageType}</td>
-        <td>{build.buildInfo.baseOs}</td>
-        <td>{build.buildInfo.targetPlatform}</td>
+        <td>{imageType}</td>
+        <td>{buildInfo.baseOs}</td>
+        <td>{buildInfo.targetPlatform}</td>
       </tr>
       {/* Inline failure reason row (visible without expanding) */}
-      {build.status === 'failed' && build.failure?.reason && !expanded && (
+      {status === 'failed' && failure?.reason && !expanded && (
         <tr>
           <td aria-label="spacer" />
           <td aria-label="spacer" />
           <td colSpan={5} style={{ padding: '2px 8px', fontSize: '0.8em', opacity: 0.7 }}>
-            {build.failure.reason.slice(0, 200)}
-            {build.failure.reason.length > 200 ? '...' : ''}
+            {failure.reason.slice(0, 200)}
+            {failure.reason.length > 200 ? '...' : ''}
           </td>
         </tr>
       )}
@@ -179,7 +184,7 @@ export default function BuildRow({ children, build, selected, onToggleSelect }: 
               </div>
             )}
             {/* Failure log viewer */}
-            {build.status === 'failed' && build.failure && (
+            {status === 'failed' && failure && (
               <div
                 style={{
                   padding: '8px 12px',
@@ -190,8 +195,8 @@ export default function BuildRow({ children, build, selected, onToggleSelect }: 
                   fontSize: '0.8em',
                 }}
               >
-                <strong>Failure reason:</strong> {build.failure.reason || 'Unknown'}
-                {build.failure.log && (
+                <strong>Failure reason:</strong> {failure.reason || 'Unknown'}
+                {failure.log && (
                   <details style={{ marginTop: 4 }}>
                     <summary style={{ cursor: 'pointer', opacity: 0.8 }}>Build log</summary>
                     <pre
@@ -208,7 +213,7 @@ export default function BuildRow({ children, build, selected, onToggleSelect }: 
                         wordBreak: 'break-all',
                       }}
                     >
-                      {build.failure.log}
+                      {failure.log}
                     </pre>
                   </details>
                 )}

--- a/src/components/docs/versions/builds/build-row.tsx
+++ b/src/components/docs/versions/builds/build-row.tsx
@@ -2,26 +2,40 @@ import React, { useState } from 'react';
 import DockerImageLinkOrRetryButton, {
   type Record,
 } from '@site/src/components/docs/versions/docker-image-link-or-retry-button';
+import { SimpleAuthCheck } from '@site/src/components/auth/safe-auth-check';
 import Spinner from '@site/src/components/molecules/spinner';
 import Tooltip from '@site/src/components/molecules/tooltip/tooltip';
 import styles from './builds.module.scss';
 
 const mapBuildStatusToIcon = {
   started: <Spinner type="slow" />,
-  failed: '⚠',
-  published: '✅',
+  failed: '\u26A0',
+  published: '\u2705',
 };
 
 type Props = {
   children: React.JSX.Element | React.JSX.Element[];
   build: Record;
+  selected: boolean;
+  onToggleSelect: () => void;
 };
 
 const CopyToClipboard = (copyString: string) => {
   navigator.clipboard.writeText(copyString);
 };
 
-export default function BuildRow({ children, build }: Props) {
+const formatTimestamp = (ts: any): string => {
+  if (!ts) return '';
+  const date = ts.seconds ? new Date(ts.seconds * 1000) : new Date(ts);
+  return date.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+};
+
+export default function BuildRow({ children, build, selected, onToggleSelect }: Props) {
   const [expanded, setExpanded] = useState(false);
   const [toolbarContent, setToolbarContent] = useState('Click to copy');
 
@@ -32,8 +46,8 @@ export default function BuildRow({ children, build }: Props) {
       case 'started':
         return <Spinner type="slow" />;
       case 'failed': {
-        const failureCount = build.meta?.failureCount || 0;
-        const label = failureCount >= 15 ? `${icon} (${failureCount}/15)` : icon;
+        const count = build.meta?.failureCount || 0;
+        const label = count >= 15 ? `${icon} (${count}/15)` : icon;
         return <Tooltip content={build.failure?.reason}>{label}</Tooltip>;
       }
       case 'published':
@@ -43,9 +57,49 @@ export default function BuildRow({ children, build }: Props) {
     }
   };
 
+  // Build timeline data
+  const meta = (build.meta || {}) as { [key: string]: any };
+  const { addedDate } = build;
+  const { lastBuildStart, lastBuildFailure, publishedDate, failureCount = 0 } = meta;
+
+  const timelineItems: { label: string; time: string; color: string }[] = [];
+  if (addedDate)
+    timelineItems.push({ label: 'Created', time: formatTimestamp(addedDate), color: '#666' });
+  if (lastBuildStart)
+    timelineItems.push({
+      label: 'Last started',
+      time: formatTimestamp(lastBuildStart),
+      color: '#3b82f6',
+    });
+  if (lastBuildFailure)
+    timelineItems.push({
+      label: `Last failure (#${failureCount})`,
+      time: formatTimestamp(lastBuildFailure),
+      color: '#ef4444',
+    });
+  if (publishedDate)
+    timelineItems.push({
+      label: 'Published',
+      time: formatTimestamp(publishedDate),
+      color: '#22c55e',
+    });
+
   return (
     <>
       <tr className={styles.tableRow}>
+        <SimpleAuthCheck fallback={<td style={{ width: 30 }} />} requiredClaims={{ admin: true }}>
+          <td style={{ width: 30, textAlign: 'center' }}>
+            {build.status === 'failed' && (
+              <input
+                type="checkbox"
+                checked={selected}
+                onChange={onToggleSelect}
+                aria-label={`Select build ${build.buildId}`}
+                style={{ cursor: 'pointer' }}
+              />
+            )}
+          </td>
+        </SimpleAuthCheck>
         <td
           onClick={() => setExpanded(!expanded)}
           className="text-center select-none cursor-pointer text-2xl"
@@ -76,9 +130,92 @@ export default function BuildRow({ children, build }: Props) {
         <td>{build.buildInfo.baseOs}</td>
         <td>{build.buildInfo.targetPlatform}</td>
       </tr>
+      {/* Inline failure reason row (visible without expanding) */}
+      {build.status === 'failed' && build.failure?.reason && !expanded && (
+        <tr>
+          <td aria-label="spacer" />
+          <td aria-label="spacer" />
+          <td colSpan={5} style={{ padding: '2px 8px', fontSize: '0.8em', opacity: 0.7 }}>
+            {build.failure.reason.slice(0, 200)}
+            {build.failure.reason.length > 200 ? '...' : ''}
+          </td>
+        </tr>
+      )}
       {expanded && (
         <tr className={styles.expandedContentRow}>
-          <td colSpan={6}>{children}</td>
+          <td colSpan={7}>
+            {/* Build timeline */}
+            {timelineItems.length > 0 && (
+              <div
+                style={{
+                  display: 'flex',
+                  flexWrap: 'wrap',
+                  gap: 16,
+                  padding: '8px 12px',
+                  marginBottom: 8,
+                  borderRadius: 6,
+                  border: '1px solid #33333322',
+                  background: '#fafafa11',
+                  fontSize: '0.8em',
+                }}
+              >
+                {timelineItems.map((item) => (
+                  <span
+                    key={item.label}
+                    style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}
+                  >
+                    <span
+                      style={{
+                        width: 8,
+                        height: 8,
+                        borderRadius: '50%',
+                        background: item.color,
+                        display: 'inline-block',
+                      }}
+                    />
+                    <strong>{item.label}:</strong> {item.time}
+                  </span>
+                ))}
+              </div>
+            )}
+            {/* Failure log viewer */}
+            {build.status === 'failed' && build.failure && (
+              <div
+                style={{
+                  padding: '8px 12px',
+                  marginBottom: 8,
+                  borderRadius: 6,
+                  border: '1px solid #ef444433',
+                  background: '#ef444411',
+                  fontSize: '0.8em',
+                }}
+              >
+                <strong>Failure reason:</strong> {build.failure.reason || 'Unknown'}
+                {build.failure.log && (
+                  <details style={{ marginTop: 4 }}>
+                    <summary style={{ cursor: 'pointer', opacity: 0.8 }}>Build log</summary>
+                    <pre
+                      style={{
+                        maxHeight: 300,
+                        overflow: 'auto',
+                        padding: 8,
+                        marginTop: 4,
+                        borderRadius: 4,
+                        background: '#1a1a1a',
+                        color: '#e5e5e5',
+                        fontSize: '0.85em',
+                        whiteSpace: 'pre-wrap',
+                        wordBreak: 'break-all',
+                      }}
+                    >
+                      {build.failure.log}
+                    </pre>
+                  </details>
+                )}
+              </div>
+            )}
+            {children}
+          </td>
         </tr>
       )}
     </>

--- a/src/components/docs/versions/builds/build-row.tsx
+++ b/src/components/docs/versions/builds/build-row.tsx
@@ -17,6 +17,7 @@ type Props = {
   children: React.JSX.Element | React.JSX.Element[];
   build: Record;
   selected: boolean;
+  jobRepoVersion: string;
   onToggleSelect: () => void;
 };
 
@@ -35,11 +36,20 @@ const formatTimestamp = (ts: any): string => {
   });
 };
 
-export default function BuildRow({ children, build, selected, onToggleSelect }: Props) {
+export default function BuildRow({
+  children,
+  build,
+  selected,
+  jobRepoVersion,
+  onToggleSelect,
+}: Props) {
   const [expanded, setExpanded] = useState(false);
   const [toolbarContent, setToolbarContent] = useState('Click to copy');
 
   const { buildId, status, failure, meta: rawMeta, addedDate, imageType, buildInfo } = build;
+  const buildRepoVersion = buildInfo.repoVersion;
+  const hasRepoVersionDrift =
+    !!jobRepoVersion && !!buildRepoVersion && jobRepoVersion !== buildRepoVersion;
 
   const MapBuildStatusToElement = (buildStatus: string) => {
     const icon = mapBuildStatusToIcon[buildStatus];
@@ -129,7 +139,34 @@ export default function BuildRow({ children, build, selected, onToggleSelect }: 
               </button>
             </Tooltip>
             <DockerImageLinkOrRetryButton record={build} />
+            {hasRepoVersionDrift && (
+              <span
+                style={{
+                  marginLeft: 8,
+                  padding: '2px 6px',
+                  borderRadius: 999,
+                  border: '1px solid #b4530933',
+                  background: '#b4530911',
+                  color: '#b45309',
+                  fontSize: '0.75em',
+                  fontWeight: 600,
+                }}
+              >
+                Repo drift
+              </span>
+            )}
           </span>
+        </td>
+        <td>
+          {hasRepoVersionDrift ? (
+            <Tooltip content="Job repo version and build repo version differ. This usually indicates retry churn against a newer repo version.">
+              <span style={{ color: '#b45309', fontWeight: 600 }}>
+                {jobRepoVersion} / {buildRepoVersion}
+              </span>
+            </Tooltip>
+          ) : (
+            buildRepoVersion
+          )}
         </td>
         <td>{imageType}</td>
         <td>{buildInfo.baseOs}</td>
@@ -140,7 +177,7 @@ export default function BuildRow({ children, build, selected, onToggleSelect }: 
         <tr>
           <td aria-label="spacer" />
           <td aria-label="spacer" />
-          <td colSpan={5} style={{ padding: '2px 8px', fontSize: '0.8em', opacity: 0.7 }}>
+          <td colSpan={6} style={{ padding: '2px 8px', fontSize: '0.8em', opacity: 0.7 }}>
             {failure.reason.slice(0, 200)}
             {failure.reason.length > 200 ? '...' : ''}
           </td>
@@ -148,7 +185,7 @@ export default function BuildRow({ children, build, selected, onToggleSelect }: 
       )}
       {expanded && (
         <tr className={styles.expandedContentRow}>
-          <td colSpan={7}>
+          <td colSpan={8}>
             {/* Build timeline */}
             {timelineItems.length > 0 && (
               <div
@@ -181,6 +218,23 @@ export default function BuildRow({ children, build, selected, onToggleSelect }: 
                     <strong>{item.label}:</strong> {item.time}
                   </span>
                 ))}
+              </div>
+            )}
+            {hasRepoVersionDrift && (
+              <div
+                style={{
+                  padding: '8px 12px',
+                  marginBottom: 8,
+                  borderRadius: 6,
+                  border: '1px solid #b4530933',
+                  background: '#b4530911',
+                  fontSize: '0.8em',
+                }}
+              >
+                <strong>Repo-version drift detected:</strong> job repo version is `{jobRepoVersion}`
+                while this build carries repo version `{buildRepoVersion}`. That usually means an
+                older failed job is being retried against the latest repo version instead of being
+                superseded.
               </div>
             )}
             {/* Failure log viewer */}

--- a/src/components/docs/versions/builds/build-row.tsx
+++ b/src/components/docs/versions/builds/build-row.tsx
@@ -9,8 +9,8 @@ import styles from './builds.module.scss';
 
 const mapBuildStatusToIcon = {
   started: <Spinner type="slow" />,
-  failed: '\u26A0',
-  published: '\u2705',
+  failed: '⚠',
+  published: '✅',
 };
 
 type Props = {
@@ -177,7 +177,7 @@ export default function BuildRow({
         <tr>
           <td aria-label="spacer" />
           <td aria-label="spacer" />
-          <td colSpan={6} style={{ padding: '2px 8px', fontSize: '0.8em', opacity: 0.7 }}>
+          <td colSpan={8} style={{ padding: '2px 8px', fontSize: '0.8em', opacity: 0.7 }}>
             {failure.reason.slice(0, 200)}
             {failure.reason.length > 200 ? '...' : ''}
           </td>

--- a/src/components/docs/versions/builds/builds.tsx
+++ b/src/components/docs/versions/builds/builds.tsx
@@ -201,6 +201,7 @@ const Builds = ({ ciJobId, repoVersionInfo, editorVersionInfo }: Props) => {
             <th> </th>
             <th className="text-center">Status</th>
             <th>Build ID</th>
+            <th>Repo Version</th>
             <th>Image type</th>
             <th>OS</th>
             <th>Target Platform</th>
@@ -212,6 +213,7 @@ const Builds = ({ ciJobId, repoVersionInfo, editorVersionInfo }: Props) => {
               key={build.buildId}
               build={build}
               selected={selectedBuilds.has(build.buildId)}
+              jobRepoVersion={repoVersionInfo.version}
               onToggleSelect={() => toggleBuild(build.buildId)}
             >
               {expandable.expandedRowRender(build)}

--- a/src/components/docs/versions/builds/builds.tsx
+++ b/src/components/docs/versions/builds/builds.tsx
@@ -54,6 +54,7 @@ const BulkActions = ({ selectedIds, onClear }: { selectedIds: string[]; onClear:
       const batchSize = 5;
       for (let offset = 0; offset < selectedIds.length; offset += batchSize) {
         const batch = selectedIds.slice(offset, offset + batchSize);
+        // eslint-disable-next-line no-await-in-loop -- sequential batching is intentional
         const results = await Promise.allSettled(
           batch.map((buildId) => callEndpoint(endpoint, { buildId })),
         );

--- a/src/components/docs/versions/builds/builds.tsx
+++ b/src/components/docs/versions/builds/builds.tsx
@@ -1,6 +1,10 @@
-import React from 'react';
-import { useFirestore, useFirestoreCollectionData } from 'reactfire';
+import React, { useState } from 'react';
+import { useFirestore, useFirestoreCollectionData, useUser } from 'reactfire';
 import BuildFailureDetails from '@site/src/components/docs/versions/builds/build-failure-details';
+import { SimpleAuthCheck } from '@site/src/components/auth/safe-auth-check';
+import { useNotification } from '@site/src/core/hooks/use-notification';
+import config from '@site/src/core/config';
+import Spinner from '@site/src/components/molecules/spinner';
 import styles from './builds.module.scss';
 import BuildRow from './build-row';
 import { Record } from '../docker-image-link-or-retry-button';
@@ -18,8 +22,112 @@ interface Props {
   editorVersionInfo;
 }
 
+const BulkActions = ({ selectedIds, onClear }: { selectedIds: string[]; onClear: () => void }) => {
+  const [running, setRunning] = useState(false);
+  const notify = useNotification();
+  const { data: user } = useUser();
+
+  const callEndpoint = async (endpoint: string, payload: object) => {
+    const token = await user.getIdToken();
+    const response = await fetch(`${config.backendUrl}/${endpoint}`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      mode: 'cors',
+      method: 'POST',
+      body: JSON.stringify(payload),
+    });
+    const body = await response.json();
+    if (!response.ok) {
+      const detail = body.error ? `${body.message}: ${body.error}` : body.message;
+      throw new Error(detail || `Request failed (${response.status})`);
+    }
+    return body;
+  };
+
+  const runBulkAction = async (endpoint: string, label: string) => {
+    setRunning(true);
+    try {
+      let succeeded = 0;
+      let failed = 0;
+      const batchSize = 5;
+      for (let offset = 0; offset < selectedIds.length; offset += batchSize) {
+        const batch = selectedIds.slice(offset, offset + batchSize);
+        const results = await Promise.allSettled(
+          batch.map((buildId) => callEndpoint(endpoint, { buildId })),
+        );
+        succeeded += results.filter((r) => r.status === 'fulfilled').length;
+        failed += results.filter((r) => r.status === 'rejected').length;
+      }
+      if (failed > 0) {
+        notify.error(`${label} ${succeeded}/${selectedIds.length}. ${failed} failed.`);
+      } else {
+        notify.success(`${label} ${succeeded} of ${selectedIds.length} builds`);
+      }
+      onClear();
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  if (selectedIds.length === 0) return null;
+
+  const barStyle: React.CSSProperties = {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 8,
+    padding: '6px 12px',
+    marginBottom: 8,
+    borderRadius: 6,
+    border: '1px solid #3b82f633',
+    background: '#3b82f611',
+    fontSize: '0.85em',
+  };
+
+  const buttonStyle: React.CSSProperties = {
+    padding: '2px 10px',
+    borderRadius: 4,
+    border: '1px solid #ccc',
+    background: 'transparent',
+    cursor: running ? 'wait' : 'pointer',
+    fontSize: '0.85em',
+  };
+
+  return (
+    <div style={barStyle}>
+      <strong>{selectedIds.length} selected</strong>
+      <button
+        type="button"
+        style={buttonStyle}
+        onClick={() => runBulkAction('resetFailedBuilds', 'Reset')}
+        disabled={running}
+      >
+        {running ? <Spinner type="spin" /> : 'Reset failure counts'}
+      </button>
+      <button
+        type="button"
+        style={buttonStyle}
+        onClick={() => runBulkAction('retryBuild', 'Retried')}
+        disabled={running}
+      >
+        {running ? <Spinner type="spin" /> : 'Retry builds'}
+      </button>
+      <button
+        type="button"
+        style={{ ...buttonStyle, marginLeft: 'auto' }}
+        onClick={onClear}
+        disabled={running}
+      >
+        Clear selection
+      </button>
+    </div>
+  );
+};
+
 const Builds = ({ ciJobId, repoVersionInfo, editorVersionInfo }: Props) => {
   const loading = <p>Fetching builds...</p>;
+  const [selectedBuilds, setSelectedBuilds] = useState<Set<string>>(new Set());
 
   const ciBuilds = useFirestore().collection('ciBuilds').where('relatedJobId', '==', ciJobId);
 
@@ -29,6 +137,24 @@ const Builds = ({ ciJobId, repoVersionInfo, editorVersionInfo }: Props) => {
   if (isLoading) {
     return loading;
   }
+
+  const toggleBuild = (buildId: string) => {
+    setSelectedBuilds((previous) => {
+      const next = new Set(previous);
+      if (next.has(buildId)) next.delete(buildId);
+      else next.add(buildId);
+      return next;
+    });
+  };
+
+  const toggleAll = () => {
+    const failedBuilds = data.filter((b) => b.status === 'failed');
+    if (selectedBuilds.size === failedBuilds.length && failedBuilds.length > 0) {
+      setSelectedBuilds(new Set());
+    } else {
+      setSelectedBuilds(new Set(failedBuilds.map((b) => b.buildId)));
+    }
+  };
 
   const expandable = {
     expandedRowRender: (record) => (
@@ -42,20 +168,57 @@ const Builds = ({ ciJobId, repoVersionInfo, editorVersionInfo }: Props) => {
     ),
   };
 
+  const failedCount = data.filter((b) => b.status === 'failed').length;
+
   return (
-    <table className="w-full max-w-screen-lg block border-collapse">
-      <tr className={styles.tableRow}>
-        <th> </th>
-        <th className="text-center">Status</th>
-        <th>Build ID</th>
-        <th>Image type</th>
-        <th>OS</th>
-        <th>Target Platform</th>
-      </tr>
-      {data.map((build: Record) => (
-        <BuildRow build={build}>{expandable.expandedRowRender(build)}</BuildRow>
-      ))}
-    </table>
+    <>
+      <SimpleAuthCheck fallback={<span />} requiredClaims={{ admin: true }}>
+        <BulkActions
+          selectedIds={[...selectedBuilds]}
+          onClear={() => setSelectedBuilds(new Set())}
+        />
+      </SimpleAuthCheck>
+      <table className="w-full max-w-screen-lg block border-collapse">
+        <thead>
+          <tr className={styles.tableRow}>
+            <SimpleAuthCheck
+              fallback={<th style={{ width: 30 }}> </th>}
+              requiredClaims={{ admin: true }}
+            >
+              <th style={{ width: 30 }}>
+                {failedCount > 0 && (
+                  <input
+                    type="checkbox"
+                    checked={selectedBuilds.size === failedCount && failedCount > 0}
+                    onChange={toggleAll}
+                    title="Select all failed builds"
+                    style={{ cursor: 'pointer' }}
+                  />
+                )}
+              </th>
+            </SimpleAuthCheck>
+            <th> </th>
+            <th className="text-center">Status</th>
+            <th>Build ID</th>
+            <th>Image type</th>
+            <th>OS</th>
+            <th>Target Platform</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((build: Record) => (
+            <BuildRow
+              key={build.buildId}
+              build={build}
+              selected={selectedBuilds.has(build.buildId)}
+              onToggleSelect={() => toggleBuild(build.buildId)}
+            >
+              {expandable.expandedRowRender(build)}
+            </BuildRow>
+          ))}
+        </tbody>
+      </table>
+    </>
   );
 };
 

--- a/src/components/docs/versions/builds/builds.tsx
+++ b/src/components/docs/versions/builds/builds.tsx
@@ -28,6 +28,9 @@ const BulkActions = ({ selectedIds, onClear }: { selectedIds: string[]; onClear:
   const { data: user } = useUser();
 
   const callEndpoint = async (endpoint: string, payload: object) => {
+    if (!user) {
+      throw new Error('User not authenticated');
+    }
     const token = await user.getIdToken();
     const response = await fetch(`${config.backendUrl}/${endpoint}`, {
       headers: {

--- a/src/components/docs/versions/image-versions.tsx
+++ b/src/components/docs/versions/image-versions.tsx
@@ -4,6 +4,8 @@ import CleanUpStuckBuildsButton from './clean-up-stuck-builds-button';
 import ResetAllFailedBuildsButton from './reset-all-failed-builds-button';
 import BuildStatusDashboard from './build-status-dashboard';
 import UnityVersions from './unity-versions';
+import QueueManagementPanel from './queue-management-panel';
+import { SimpleAuthCheck } from '@site/src/components/auth/safe-auth-check';
 import styles from './unity-version.module.scss';
 
 interface Props {
@@ -64,6 +66,10 @@ const ImageVersions = ({ versions }: Props) => {
       </div>
 
       <BuildStatusDashboard selectedRepoVersion={selectedVersion} />
+
+      <SimpleAuthCheck fallback={<span />} requiredClaims={{ admin: true }}>
+        <QueueManagementPanel selectedRepoVersion={selectedVersion} />
+      </SimpleAuthCheck>
 
       <div style={filterBarStyle}>
         <input

--- a/src/components/docs/versions/image-versions.tsx
+++ b/src/components/docs/versions/image-versions.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import SignInSignOutButton from '@site/src/components/auth/sign-in-sign-out-button';
 import CleanUpStuckBuildsButton from './clean-up-stuck-builds-button';
 import ResetAllFailedBuildsButton from './reset-all-failed-builds-button';
+import BuildStatusDashboard from './build-status-dashboard';
 import UnityVersions from './unity-versions';
 import styles from './unity-version.module.scss';
 
@@ -9,8 +10,33 @@ interface Props {
   versions: { [key: string]: any }[];
 }
 
+export type StatusFilter = 'all' | 'started' | 'failed' | 'published' | 'stuck';
+
 const ImageVersions = ({ versions }: Props) => {
   const [selectedVersion, setSelectedVersion] = useState<any>(versions[0].NO_ID_FIELD);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
+
+  const filterBarStyle: React.CSSProperties = {
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: 8,
+    alignItems: 'center',
+    padding: '8px 0',
+  };
+
+  const selectStyle: React.CSSProperties = {
+    padding: '4px 8px',
+    borderRadius: 4,
+    border: '1px solid #ccc',
+    background: 'transparent',
+    fontSize: '0.85em',
+  };
+
+  const inputStyle: React.CSSProperties = {
+    ...selectStyle,
+    minWidth: 220,
+  };
 
   return (
     <main className={styles.versionsPanel}>
@@ -37,7 +63,53 @@ const ImageVersions = ({ versions }: Props) => {
         </span>
       </div>
 
-      <UnityVersions selectedRepoVersion={selectedVersion} />
+      <BuildStatusDashboard selectedRepoVersion={selectedVersion} />
+
+      <div style={filterBarStyle}>
+        <input
+          type="text"
+          placeholder="Search by version, platform, OS..."
+          value={searchQuery}
+          onChange={(event) => setSearchQuery(event.target.value)}
+          style={inputStyle}
+        />
+        <select
+          value={statusFilter}
+          onChange={(event) => setStatusFilter(event.target.value as StatusFilter)}
+          style={selectStyle}
+        >
+          <option value="all">All statuses</option>
+          <option value="published">Published</option>
+          <option value="started">In progress</option>
+          <option value="failed">Failed</option>
+          <option value="stuck">Stuck (15+ failures)</option>
+        </select>
+        {(searchQuery || statusFilter !== 'all') && (
+          <button
+            type="button"
+            onClick={() => {
+              setSearchQuery('');
+              setStatusFilter('all');
+            }}
+            style={{
+              padding: '4px 8px',
+              borderRadius: 4,
+              border: '1px solid #ccc',
+              background: 'transparent',
+              fontSize: '0.85em',
+              cursor: 'pointer',
+            }}
+          >
+            Clear filters
+          </button>
+        )}
+      </div>
+
+      <UnityVersions
+        selectedRepoVersion={selectedVersion}
+        searchQuery={searchQuery}
+        statusFilter={statusFilter}
+      />
     </main>
   );
 };

--- a/src/components/docs/versions/image-versions.tsx
+++ b/src/components/docs/versions/image-versions.tsx
@@ -1,11 +1,11 @@
 import React, { useState } from 'react';
 import SignInSignOutButton from '@site/src/components/auth/sign-in-sign-out-button';
+import { SimpleAuthCheck } from '@site/src/components/auth/safe-auth-check';
 import CleanUpStuckBuildsButton from './clean-up-stuck-builds-button';
 import ResetAllFailedBuildsButton from './reset-all-failed-builds-button';
 import BuildStatusDashboard from './build-status-dashboard';
 import UnityVersions from './unity-versions';
 import QueueManagementPanel from './queue-management-panel';
-import { SimpleAuthCheck } from '@site/src/components/auth/safe-auth-check';
 import styles from './unity-version.module.scss';
 
 interface Props {

--- a/src/components/docs/versions/queue-management-panel.tsx
+++ b/src/components/docs/versions/queue-management-panel.tsx
@@ -1,0 +1,382 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import config from '@site/src/core/config';
+import Spinner from '@site/src/components/molecules/spinner';
+
+type QueueJob = {
+  status: string;
+  imageType: string;
+  repoVersionInfo?: {
+    version?: string;
+  };
+};
+
+type QueueBuild = {
+  buildId: string;
+  relatedJobId: string;
+  status: string;
+  imageType: string;
+  buildInfo: {
+    repoVersion: string;
+    editorVersion: string;
+    baseOs: string;
+    targetPlatform: string;
+  };
+  dockerInfo?: {
+    digest?: string;
+  } | null;
+};
+
+type QueueStatusResponse = {
+  jobs: QueueJob[];
+  builds: QueueBuild[];
+};
+
+interface Props {
+  selectedRepoVersion: string;
+}
+
+const statStyle = (color: string): React.CSSProperties => ({
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 6,
+  padding: '4px 12px',
+  borderRadius: 6,
+  border: `1px solid ${color}33`,
+  background: `${color}11`,
+  fontSize: '0.85em',
+  fontWeight: 500,
+});
+
+const sectionStyle: React.CSSProperties = {
+  padding: '12px',
+  borderRadius: 8,
+  border: '1px solid #33333322',
+  background: '#fafafa08',
+};
+
+const tableStyle: React.CSSProperties = {
+  width: '100%',
+  borderCollapse: 'collapse',
+  fontSize: '0.85em',
+};
+
+const cellStyle: React.CSSProperties = {
+  textAlign: 'left',
+  padding: '6px 8px',
+  borderBottom: '1px solid #33333322',
+  verticalAlign: 'top',
+};
+
+const getJobRepoVersion = (job: QueueJob | undefined): string =>
+  job?.repoVersionInfo?.version || '';
+
+const QueueManagementPanel = ({ selectedRepoVersion }: Props) => {
+  const [data, setData] = useState<QueueStatusResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  const fetchQueueStatus = async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const response = await fetch(`${config.backendUrl}/queueStatus`);
+      const body = await response.json();
+      if (!response.ok) {
+        throw new Error(body.message || `Request failed (${response.status})`);
+      }
+      setData(body);
+    } catch (fetchError: any) {
+      setError(fetchError.message || 'Failed to load queue status');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void fetchQueueStatus();
+  }, []);
+
+  const diagnostics = useMemo(() => {
+    const jobs = data?.jobs || [];
+    const builds = data?.builds || [];
+    const jobMap = new Map<string, QueueJob>();
+
+    jobs.forEach((job: any) => {
+      const id = job.NO_ID_FIELD || job.id;
+      if (id) {
+        jobMap.set(id, job);
+      }
+    });
+
+    const editorJobs = jobs.filter((job) => job.imageType === 'editor');
+    const staleFailedJobs = editorJobs
+      .filter(
+        (job: any) =>
+          job.status === 'failed' &&
+          getJobRepoVersion(job) &&
+          getJobRepoVersion(job) !== selectedRepoVersion,
+      )
+      .map((job: any) => ({
+        jobId: job.NO_ID_FIELD || job.id,
+        jobRepoVersion: getJobRepoVersion(job),
+        status: job.status,
+      }));
+
+    const staleCreatedJobs = editorJobs
+      .filter(
+        (job: any) =>
+          job.status === 'created' &&
+          getJobRepoVersion(job) &&
+          getJobRepoVersion(job) !== selectedRepoVersion,
+      )
+      .map((job: any) => ({
+        jobId: job.NO_ID_FIELD || job.id,
+        jobRepoVersion: getJobRepoVersion(job),
+        status: job.status,
+      }));
+
+    const repoDriftBuilds = builds
+      .filter((build) => build.imageType === 'editor')
+      .map((build) => {
+        const job = jobMap.get(build.relatedJobId);
+        return {
+          ...build,
+          jobRepoVersion: getJobRepoVersion(job),
+        };
+      })
+      .filter(
+        (build) =>
+          build.jobRepoVersion &&
+          build.buildInfo.repoVersion &&
+          build.jobRepoVersion !== build.buildInfo.repoVersion,
+      );
+
+    const failedWithDockerInfo = builds.filter(
+      (build) => build.status === 'failed' && build.dockerInfo?.digest,
+    );
+
+    return {
+      staleFailedJobs,
+      staleCreatedJobs,
+      repoDriftBuilds,
+      failedWithDockerInfo,
+      totals: {
+        jobs: jobs.length,
+        builds: builds.length,
+        failedJobs: editorJobs.filter((job) => job.status === 'failed').length,
+        createdJobs: editorJobs.filter((job) => job.status === 'created').length,
+      },
+    };
+  }, [data, selectedRepoVersion]);
+
+  return (
+    <section style={{ ...sectionStyle, marginBottom: 16 }}>
+      <div
+        style={{
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: 8,
+          alignItems: 'center',
+          marginBottom: 12,
+        }}
+      >
+        <strong>Admin Queue Management</strong>
+        <span style={{ opacity: 0.65, fontSize: '0.85em' }}>
+          Global queue diagnostics for the selected repo version `{selectedRepoVersion}`
+        </span>
+        <button
+          type="button"
+          onClick={() => void fetchQueueStatus()}
+          style={{
+            marginLeft: 'auto',
+            padding: '4px 8px',
+            borderRadius: 4,
+            border: '1px solid #ccc',
+            background: 'transparent',
+            cursor: 'pointer',
+            fontSize: '0.85em',
+          }}
+        >
+          Refresh queue state
+        </button>
+      </div>
+
+      {loading && (
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <Spinner type="slow" /> Loading queue diagnostics...
+        </div>
+      )}
+
+      {!loading && error && (
+        <div style={{ ...statStyle('#ef4444') }}>
+          Queue diagnostics failed: <strong>{error}</strong>
+        </div>
+      )}
+
+      {!loading && !error && (
+        <>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginBottom: 12 }}>
+            <span style={statStyle('#666')}>
+              Jobs: <strong>{diagnostics.totals.jobs}</strong>
+            </span>
+            <span style={statStyle('#2563eb')}>
+              Builds: <strong>{diagnostics.totals.builds}</strong>
+            </span>
+            <span style={statStyle('#ef4444')}>
+              Failed editor jobs: <strong>{diagnostics.totals.failedJobs}</strong>
+            </span>
+            <span style={statStyle('#f59e0b')}>
+              Created editor jobs: <strong>{diagnostics.totals.createdJobs}</strong>
+            </span>
+            <span style={statStyle('#b45309')}>
+              Older-version failed jobs: <strong>{diagnostics.staleFailedJobs.length}</strong>
+            </span>
+            <span style={statStyle('#7c3aed')}>
+              Repo-version drift builds: <strong>{diagnostics.repoDriftBuilds.length}</strong>
+            </span>
+          </div>
+
+          <p style={{ opacity: 0.75, fontSize: '0.85em', marginBottom: 12 }}>
+            Use this panel to identify queue states that need intervention. Existing admin actions
+            on this page remain the operational controls: reset failed builds, retry builds, and
+            clean up stuck builds.
+          </p>
+
+          <div style={{ display: 'grid', gap: 12 }}>
+            <div>
+              <h3 style={{ marginBottom: 8 }}>Repo-Version Drift Builds</h3>
+              <table style={tableStyle}>
+                <thead>
+                  <tr>
+                    <th style={cellStyle}>Build ID</th>
+                    <th style={cellStyle}>Job ID</th>
+                    <th style={cellStyle}>Job Repo</th>
+                    <th style={cellStyle}>Build Repo</th>
+                    <th style={cellStyle}>Action</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {diagnostics.repoDriftBuilds.slice(0, 12).map((build) => (
+                    <tr key={build.buildId}>
+                      <td style={cellStyle}>{build.buildId}</td>
+                      <td style={cellStyle}>{build.relatedJobId}</td>
+                      <td style={cellStyle}>{build.jobRepoVersion}</td>
+                      <td style={cellStyle}>{build.buildInfo.repoVersion}</td>
+                      <td style={cellStyle}>
+                        Investigate retry churn. This build is attached to an older job but is
+                        retrying against a newer repo version.
+                      </td>
+                    </tr>
+                  ))}
+                  {diagnostics.repoDriftBuilds.length === 0 && (
+                    <tr>
+                      <td style={cellStyle} colSpan={5}>
+                        No repo-version drift detected.
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+
+            <div>
+              <h3 style={{ marginBottom: 8 }}>Older-Version Failed Jobs</h3>
+              <table style={tableStyle}>
+                <thead>
+                  <tr>
+                    <th style={cellStyle}>Job ID</th>
+                    <th style={cellStyle}>Job Repo</th>
+                    <th style={cellStyle}>Action</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {diagnostics.staleFailedJobs.slice(0, 12).map((job) => (
+                    <tr key={job.jobId}>
+                      <td style={cellStyle}>{job.jobId}</td>
+                      <td style={cellStyle}>{job.jobRepoVersion}</td>
+                      <td style={cellStyle}>
+                        Should be superseded so it stops competing with `{selectedRepoVersion}`.
+                      </td>
+                    </tr>
+                  ))}
+                  {diagnostics.staleFailedJobs.length === 0 && (
+                    <tr>
+                      <td style={cellStyle} colSpan={3}>
+                        No older-version failed jobs detected.
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+
+            <div>
+              <h3 style={{ marginBottom: 8 }}>Older-Version Created Jobs</h3>
+              <table style={tableStyle}>
+                <thead>
+                  <tr>
+                    <th style={cellStyle}>Job ID</th>
+                    <th style={cellStyle}>Job Repo</th>
+                    <th style={cellStyle}>Action</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {diagnostics.staleCreatedJobs.slice(0, 12).map((job) => (
+                    <tr key={job.jobId}>
+                      <td style={cellStyle}>{job.jobId}</td>
+                      <td style={cellStyle}>{job.jobRepoVersion}</td>
+                      <td style={cellStyle}>
+                        Candidate for superseding if it remains after the queue moves to the latest
+                        repo version.
+                      </td>
+                    </tr>
+                  ))}
+                  {diagnostics.staleCreatedJobs.length === 0 && (
+                    <tr>
+                      <td style={cellStyle} colSpan={3}>
+                        No older-version created jobs detected.
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+
+            <div>
+              <h3 style={{ marginBottom: 8 }}>Failed Builds With Docker Metadata</h3>
+              <table style={tableStyle}>
+                <thead>
+                  <tr>
+                    <th style={cellStyle}>Build ID</th>
+                    <th style={cellStyle}>Digest</th>
+                    <th style={cellStyle}>Action</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {diagnostics.failedWithDockerInfo.slice(0, 12).map((build) => (
+                    <tr key={build.buildId}>
+                      <td style={cellStyle}>{build.buildId}</td>
+                      <td style={cellStyle}>{build.dockerInfo?.digest}</td>
+                      <td style={cellStyle}>
+                        Reconcile this failed build against publication state before retrying.
+                      </td>
+                    </tr>
+                  ))}
+                  {diagnostics.failedWithDockerInfo.length === 0 && (
+                    <tr>
+                      <td style={cellStyle} colSpan={3}>
+                        No failed builds with Docker metadata detected.
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </>
+      )}
+    </section>
+  );
+};
+
+export default QueueManagementPanel;

--- a/src/components/docs/versions/queue-management-panel.tsx
+++ b/src/components/docs/versions/queue-management-panel.tsx
@@ -80,10 +80,17 @@ const QueueManagementPanel = ({ selectedRepoVersion }: Props) => {
     setError('');
     try {
       const response = await fetch(`${config.backendUrl}/queueStatus`);
-      const body = await response.json();
       if (!response.ok) {
-        throw new Error(body.message || `Request failed (${response.status})`);
+        let message = `Request failed (${response.status})`;
+        try {
+          const body = await response.json();
+          message = body.message || message;
+        } catch {
+          /* non-JSON response */
+        }
+        throw new Error(message);
       }
+      const body = await response.json();
       setData(body);
     } catch (fetchError: any) {
       setError(fetchError.message || 'Failed to load queue status');
@@ -93,7 +100,7 @@ const QueueManagementPanel = ({ selectedRepoVersion }: Props) => {
   };
 
   useEffect(() => {
-    void fetchQueueStatus();
+    fetchQueueStatus();
   }, []);
 
   const diagnostics = useMemo(() => {
@@ -101,12 +108,12 @@ const QueueManagementPanel = ({ selectedRepoVersion }: Props) => {
     const builds = data?.builds || [];
     const jobMap = new Map<string, QueueJob>();
 
-    jobs.forEach((job: any) => {
-      const id = job.NO_ID_FIELD || job.id;
+    for (const job of jobs) {
+      const id = (job as any).NO_ID_FIELD || (job as any).id;
       if (id) {
         jobMap.set(id, job);
       }
-    });
+    }
 
     const editorJobs = jobs.filter((job) => job.imageType === 'editor');
     const staleFailedJobs = editorJobs
@@ -186,7 +193,9 @@ const QueueManagementPanel = ({ selectedRepoVersion }: Props) => {
         </span>
         <button
           type="button"
-          onClick={() => void fetchQueueStatus()}
+          onClick={() => {
+            fetchQueueStatus();
+          }}
           style={{
             marginLeft: 'auto',
             padding: '4px 8px',

--- a/src/components/docs/versions/unity-versions.tsx
+++ b/src/components/docs/versions/unity-versions.tsx
@@ -2,13 +2,15 @@ import React from 'react';
 import { useFirestore, useFirestoreCollectionData } from 'reactfire';
 import UnityVersion from '@site/src/components/docs/versions/unity-version';
 import MajorEditorVersion from './major-editor-version';
+import type { StatusFilter } from './image-versions';
 
 interface Props {
   selectedRepoVersion: string | undefined;
-  // setIsLoading: Dispatch<SetStateAction<boolean>>;
+  searchQuery: string;
+  statusFilter: StatusFilter;
 }
 
-const UnityVersions = ({ selectedRepoVersion }: Props) => {
+const UnityVersions = ({ selectedRepoVersion, searchQuery, statusFilter }: Props) => {
   if (!selectedRepoVersion) return null;
 
   const ciJobs = useFirestore()
@@ -22,34 +24,51 @@ const UnityVersions = ({ selectedRepoVersion }: Props) => {
   const isLoading = status === 'loading';
 
   const loading = <p>Fetching versions...</p>;
-  const failures = isLoading ? [] : data.filter((version) => version.status === 'failed');
+
+  // Apply filters
+  let filtered = isLoading ? [] : [...data];
+
+  // Status filter
+  if (statusFilter !== 'all') {
+    filtered = filtered.filter((version) => {
+      if (statusFilter === 'stuck') {
+        return version.status === 'failed';
+      }
+      return version.status === statusFilter;
+    });
+  }
+
+  // Search filter (matches against the job ID which contains version info)
+  if (searchQuery) {
+    const q = searchQuery.toLowerCase();
+    filtered = filtered.filter((version) => {
+      const id = (version.NO_ID_FIELD || '').toLowerCase();
+      const editor = version.editorVersionInfo
+        ? `${version.editorVersionInfo.major}.${version.editorVersionInfo.minor}.${version.editorVersionInfo.patch}`
+        : '';
+      return id.toLowerCase().includes(q) || editor.toLowerCase().includes(q);
+    });
+  }
+
+  const failures = filtered.filter((version) => version.status === 'failed');
 
   const versions = {};
 
-  if (data) {
+  if (filtered.length > 0) {
     // Sorting the data based on the version numbers to maintain the version order
-    data.sort((a, b) => {
+    filtered.sort((a, b) => {
       const infoA = a.editorVersionInfo;
       const infoB = b.editorVersionInfo;
 
-      // Using major , minor and patch to compare the two numbers
       const { major: majorA, minor: minorA, patch: patchA } = infoA;
       const { major: majorB, minor: minorB, patch: patchB } = infoB;
 
-      // First checking for major version.
       if (majorA > majorB) return -1;
       if (majorA < majorB) return 1;
 
-      // If major version is equal check for minor version.
       if (minorA > minorB) return -1;
       if (minorA < minorB) return 1;
 
-      // If major and minor both are equal check the patch version.
-
-      // For patch assuming "f" is present and splitting based on that.(Can use regex to split also).
-
-      // Calculating a patchNumber which is the priority offset based sum of the numbers in
-      // the array formed after split. The offset is used to correctly get the priority.
       let patchANumber = 0;
       for (const [index, currentValue] of patchA.split('f').entries()) {
         patchANumber += 10 ** (9 - 3 * index) * Number.parseInt(currentValue, 10);
@@ -63,8 +82,7 @@ const UnityVersions = ({ selectedRepoVersion }: Props) => {
     });
 
     // Sort versions into organized array by major version number
-    data.map((version) => {
-      // Ignore if version is older than 2018.x
+    filtered.map((version) => {
       if (Number.parseInt(version.editorVersionInfo.major, 10) <= 2017) return version;
 
       if (!versions[version.editorVersionInfo.major])
@@ -78,8 +96,16 @@ const UnityVersions = ({ selectedRepoVersion }: Props) => {
     });
   }
 
+  const hasFilters = searchQuery || statusFilter !== 'all';
+
   return (
     <main>
+      {hasFilters && !isLoading && (
+        <p style={{ opacity: 0.6, fontSize: '0.85em' }}>
+          Showing {filtered.length} of {data.length} versions
+        </p>
+      )}
+
       {failures.length > 0 && (
         <>
           <h3>Current failures</h3>
@@ -95,7 +121,7 @@ const UnityVersions = ({ selectedRepoVersion }: Props) => {
           : Object.keys(versions)
               .reverse()
               .map((major) => (
-                <MajorEditorVersion versionString={major} versions={versions[major]} />
+                <MajorEditorVersion key={major} versionString={major} versions={versions[major]} />
               ))}
       </div>
     </main>

--- a/src/components/docs/versions/unity-versions.tsx
+++ b/src/components/docs/versions/unity-versions.tsx
@@ -11,16 +11,17 @@ interface Props {
 }
 
 const UnityVersions = ({ selectedRepoVersion, searchQuery, statusFilter }: Props) => {
-  if (!selectedRepoVersion) return null;
-
-  const ciJobs = useFirestore()
+  const firestore = useFirestore();
+  const ciJobs = firestore
     .collection('ciJobs')
     .orderBy('editorVersionInfo.major', 'desc')
     .orderBy('editorVersionInfo.minor', 'desc')
     .orderBy('editorVersionInfo.patch', 'desc')
-    .where('repoVersionInfo.version', '==', selectedRepoVersion);
+    .where('repoVersionInfo.version', '==', selectedRepoVersion || '__none__');
 
   const { status, data } = useFirestoreCollectionData<{ [key: string]: any }>(ciJobs);
+
+  if (!selectedRepoVersion) return null;
   const isLoading = status === 'loading';
 
   const loading = <p>Fetching versions...</p>;
@@ -32,7 +33,7 @@ const UnityVersions = ({ selectedRepoVersion, searchQuery, statusFilter }: Props
   if (statusFilter !== 'all') {
     filtered = filtered.filter((version) => {
       if (statusFilter === 'stuck') {
-        return version.status === 'failed';
+        return version.status === 'failed' && (version.meta?.failureCount || 0) >= 15;
       }
       return version.status === statusFilter;
     });


### PR DESCRIPTION
## Summary

Comprehensive admin enhancements for the Docker versions page:

- **Build status dashboard**: Live counts of published/in-progress/failed/stuck builds with green "Live" indicator (Firestore real-time listener)
- **Bulk retry**: Checkbox selection on failed builds with "Reset failure counts" and "Retry builds" bulk action bar. Batched in groups of 5 to handle large volumes
- **Build logs viewer**: Failure reason shown inline on failed builds (no need to expand), expandable build log in details panel
- **Filter/search**: Search by version/platform/OS text, filter dropdown by status (all, published, in progress, failed, stuck 15+), with "Clear filters" button and result count
- **Auto-refresh**: Firestore `useFirestoreCollectionData` provides real-time updates automatically. Added green "Live" indicator to dashboard
- **Build timeline**: Timestamps for Created, Last started, Last failure (with count), and Published dates shown in expandable details

### Files changed
- **NEW** `build-status-dashboard.tsx` — Live build count dashboard
- `image-versions.tsx` — Added dashboard, search input, status filter dropdown
- `unity-versions.tsx` — Accepts and applies search/status filters with result count
- `builds/builds.tsx` — Bulk action bar with checkbox select-all, batched API calls
- `builds/build-row.tsx` — Checkboxes, inline failure reason, timeline, log viewer

## Test plan
- [ ] Dashboard shows correct counts for published/failed/started builds
- [ ] Search filters versions by editor version text
- [ ] Status dropdown filters to show only failed/published/in-progress/stuck
- [ ] Checkboxes appear on failed builds when signed in as admin
- [ ] Select-all checkbox selects all failed builds in a job
- [ ] Bulk "Reset failure counts" resets selected builds
- [ ] Bulk "Retry builds" retries selected builds
- [ ] Failed build shows failure reason inline without expanding
- [ ] Expanding a failed build shows timeline + failure details + log
- [ ] Timeline shows correct timestamps for build lifecycle
- [ ] Green "Live" indicator pulses in dashboard
- [ ] Large number of builds (100+) doesn't cause performance issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live build status dashboard with totals, colored pills, “Stuck (15+)” indicator and live pulse.
  * Admin-only bulk selection/actions for failed builds (retry, reset) with progress and notifications.
  * Selectable build rows, repo-version drift badges/details, inline failure excerpts, timeline and expandable logs.
  * Search and status filtering for versions with “Showing X of Y” indicator.
  * Admin queue diagnostics panel with refreshable summaries and tables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->