### PR TITLE
docs: clarify CLI command surfaces

### DIFF
--- a/docs/03-github-cli/02-build.mdx
+++ b/docs/03-github-cli/02-build.mdx
@@ -185,5 +185,5 @@ version.
 
 ## See Also
 
-- [Remote jobs](/docs/cli/remote-builds)
+- [Orchestrated jobs](/docs/cli/remote-builds)
 - [Configuration and plugins](/docs/cli/configuration-and-plugins)

--- a/docs/03-github-cli/03-remote-builds.mdx
+++ b/docs/03-github-cli/03-remote-builds.mdx
@@ -170,7 +170,7 @@ Orchestrated jobs can load the provider plugin and common options from `.game-ci
 ```yaml
 cliOptions:
   plugins:
-    - "@game-ci/orchestrator-plugin"
+    - '@game-ci/orchestrator-plugin'
   providerStrategy: local-docker
   targetPlatform: StandaloneLinux64
 ```

--- a/docs/03-github-cli/03-remote-builds.mdx
+++ b/docs/03-github-cli/03-remote-builds.mdx
@@ -1,49 +1,51 @@
 ---
 sidebar_position: 3
-sidebar_label: Remote Jobs
+sidebar_label: Orchestrate
 slug: /cli/remote-builds
 ---
 
-# Remote Jobs
+# Orchestrated Jobs
 
-`game-ci remote run` schedules a provider-backed engine job. Providers can run standard builds, test
+`game-ci orchestrate` schedules a provider-backed engine job. Providers can run standard builds, test
 workflows, custom engine commands, or a fully custom job definition.
 
 ```bash
-game-ci remote run [projectPath] --provider-strategy <strategy>
+game-ci orchestrate [projectPath] --provider-strategy <strategy>
 ```
 
-`game-ci remote build` remains available as a compatibility alias, but new workflows should use
-`remote run` so the command name matches the broader job model.
+`game-ci remote run` and `game-ci remote build` remain available as compatibility aliases, but new
+workflows should use `game-ci orchestrate` so the command name matches the provider-backed job
+model.
 
 The CLI owns the high-level command shape. Providers own infrastructure-specific options and job
 execution behavior.
 
-## Remote Run vs Standalone Orchestrate
+## Public CLI vs Standalone Orchestrator
 
-Use `game-ci remote run` from the public CLI for normal remote jobs. It keeps the command model
-engine-oriented and lets provider plugins add infrastructure details.
+Use `game-ci orchestrate` from the public CLI for normal provider-backed jobs. It keeps the command
+model engine-oriented and lets provider plugins add infrastructure details.
 
 The standalone Orchestrator package also installs a `game-ci orchestrate` command. That command is a
 direct, lower-level Orchestrator entry point for provider development, debugging, and environments
-that intentionally run Orchestrator without the public CLI. It is not the preferred public CLI
-command.
+that intentionally run Orchestrator without the public CLI. The verb is the same, but the installed
+package determines the command surface.
 
 | Need                                                     | Use                                  |
 | -------------------------------------------------------- | ------------------------------------ |
-| Friendly public CLI command for builds, tests, or jobs   | `game-ci remote run`                 |
-| Backwards-compatible old remote command name             | `game-ci remote build`               |
+| Friendly public CLI command for builds, tests, or jobs   | `game-ci orchestrate`                |
+| Backwards-compatible old public CLI command names        | `game-ci remote run`, `remote build` |
 | Direct standalone Orchestrator provider execution        | `game-ci orchestrate`                |
 | Executable provider protocol integration with GameCI CLI | `game-ci serve` in the provider tool |
 
 ## Orchestrator Plugin
 
-The Orchestrator is the default provider backend for remote execution. Load it as a CLI plugin:
+The Orchestrator is the default provider backend for provider-backed execution. Load it as a CLI
+plugin:
 
 ```bash
 game-ci \
   --plugin @game-ci/orchestrator-plugin \
-  remote run ./my-unity-project \
+  orchestrate ./my-unity-project \
   --provider-strategy local-docker \
   --target-platform StandaloneLinux64
 ```
@@ -69,7 +71,7 @@ Available Orchestrator provider types include:
 ```bash
 game-ci \
   --plugin @game-ci/orchestrator-plugin \
-  remote run ./my-unity-project \
+  orchestrate ./my-unity-project \
   --provider-strategy local-docker \
   --target-platform StandaloneLinux64
 ```
@@ -85,7 +87,7 @@ export AWS_DEFAULT_REGION=us-east-1
 
 game-ci \
   --plugin @game-ci/orchestrator-plugin \
-  remote run ./my-unity-project \
+  orchestrate ./my-unity-project \
   --provider-strategy aws \
   --target-platform StandaloneLinux64 \
   --container-cpu 2048 \
@@ -113,7 +115,7 @@ profiles, SSO sessions, and runner roles.
 ```bash
 game-ci \
   --plugin @game-ci/orchestrator-plugin \
-  remote run ./my-unity-project \
+  orchestrate ./my-unity-project \
   --provider-strategy k8s \
   --target-platform StandaloneLinux64 \
   --kube-config "$KUBE_CONFIG_BASE64" \
@@ -138,7 +140,7 @@ or test command.
 ```bash
 game-ci \
   --plugin @game-ci/orchestrator-plugin \
-  remote run ./my-godot-project \
+  orchestrate ./my-godot-project \
   --provider-strategy local-docker \
   --custom-job '- name: godot-export
   image: barichello/godot-ci:4.3
@@ -154,7 +156,7 @@ protocol. Load the executable as a plugin and select the generated provider stra
 ```bash
 game-ci \
   --plugin executable:./my-provider \
-  remote run ./my-project \
+  orchestrate ./my-project \
   --provider-strategy cli-protocol
 ```
 
@@ -163,12 +165,12 @@ For protocol details, see
 
 ## Configuration Files
 
-Remote jobs can load the provider plugin and common options from `.game-ci.yml`:
+Orchestrated jobs can load the provider plugin and common options from `.game-ci.yml`:
 
 ```yaml
 cliOptions:
   plugins:
-    - '@game-ci/orchestrator-plugin'
+    - "@game-ci/orchestrator-plugin"
   providerStrategy: local-docker
   targetPlatform: StandaloneLinux64
 ```
@@ -176,7 +178,7 @@ cliOptions:
 Then the command can stay short:
 
 ```bash
-game-ci remote run ./my-project
+game-ci orchestrate ./my-project
 ```
 
 Provider-specific options are registered by the loaded plugin, so run with `--help` after loading

--- a/docs/03-github-cli/03-remote-builds.mdx
+++ b/docs/03-github-cli/03-remote-builds.mdx
@@ -19,6 +19,23 @@ game-ci remote run [projectPath] --provider-strategy <strategy>
 The CLI owns the high-level command shape. Providers own infrastructure-specific options and job
 execution behavior.
 
+## Remote Run vs Standalone Orchestrate
+
+Use `game-ci remote run` from the public CLI for normal remote jobs. It keeps the command model
+engine-oriented and lets provider plugins add infrastructure details.
+
+The standalone Orchestrator package also installs a `game-ci orchestrate` command. That command is a
+direct, lower-level Orchestrator entry point for provider development, debugging, and environments
+that intentionally run Orchestrator without the public CLI. It is not the preferred public CLI
+command.
+
+| Need                                                     | Use                                  |
+| -------------------------------------------------------- | ------------------------------------ |
+| Friendly public CLI command for builds, tests, or jobs   | `game-ci remote run`                 |
+| Backwards-compatible old remote command name             | `game-ci remote build`               |
+| Direct standalone Orchestrator provider execution        | `game-ci orchestrate`                |
+| Executable provider protocol integration with GameCI CLI | `game-ci serve` in the provider tool |
+
 ## Orchestrator Plugin
 
 The Orchestrator is the default provider backend for remote execution. Load it as a CLI plugin:
@@ -31,21 +48,21 @@ game-ci \
   --target-platform StandaloneLinux64
 ```
 
-Available provider strategies from the Orchestrator plugin include:
+Available Orchestrator provider types include:
 
-| Strategy            | Description                                    |
-| ------------------- | ---------------------------------------------- |
-| `local-docker`      | Run the job in Docker on the current machine.  |
-| `local-system`      | Run directly on the current machine.           |
-| `aws`               | Run on AWS ECS/Fargate.                        |
-| `k8s`               | Run as a Kubernetes job.                       |
-| `gcp-cloud-run`     | Run on Google Cloud Run.                       |
-| `azure-aci`         | Run on Azure Container Instances.              |
-| `github-actions`    | Dispatch to a GitHub Actions workflow.         |
-| `gitlab-ci`         | Trigger a GitLab CI pipeline.                  |
-| `remote-powershell` | Run on a remote Windows host over PowerShell.  |
-| `ansible`           | Run through an Ansible inventory and playbook. |
-| `cli`               | Delegate to a custom provider executable.      |
+| Provider type     | Strategy value      | Description                                    |
+| ----------------- | ------------------- | ---------------------------------------------- |
+| Local Docker      | `local-docker`      | Run the job in Docker on the current machine.  |
+| Local System      | `local-system`      | Run directly on the current machine.           |
+| AWS               | `aws`               | Run on AWS ECS/Fargate.                        |
+| Kubernetes        | `k8s`               | Run as a Kubernetes job.                       |
+| Google Cloud Run  | `gcp-cloud-run`     | Run on Google Cloud Run.                       |
+| Azure ACI         | `azure-aci`         | Run on Azure Container Instances.              |
+| GitHub Actions    | `github-actions`    | Dispatch to a GitHub Actions workflow.         |
+| GitLab CI         | `gitlab-ci`         | Trigger a GitLab CI pipeline.                  |
+| Remote PowerShell | `remote-powershell` | Run on a remote Windows host.                  |
+| Ansible           | `ansible`           | Run through an Ansible inventory and playbook. |
+| CLI protocol      | `cli`               | Delegate to a custom provider executable.      |
 
 ## Local Docker
 

--- a/docs/03-github-cli/04-configuration-and-plugins.mdx
+++ b/docs/03-github-cli/04-configuration-and-plugins.mdx
@@ -23,7 +23,7 @@ Options live under `cliOptions`.
 ```yaml
 cliOptions:
   plugin:
-    - "@game-ci/orchestrator-plugin"
+    - '@game-ci/orchestrator-plugin'
   verbose: true
   targetPlatform: StandaloneLinux64
   buildsPath: dist
@@ -63,7 +63,7 @@ You can also add the plugin to `.game-ci.yml`:
 ```yaml
 cliOptions:
   plugins:
-    - "@game-ci/orchestrator-plugin"
+    - '@game-ci/orchestrator-plugin'
   providerStrategy: local-docker
   targetPlatform: StandaloneLinux64
 ```
@@ -94,28 +94,28 @@ commands, test commands, option registration, providers, and an `onLoad` hook.
 
 ```ts
 export default {
-  name: "my-engine",
-  version: "1.0.0",
+  name: 'my-engine',
+  version: '1.0.0',
   engineDetectors: [
     {
-      name: "my-engine",
+      name: 'my-engine',
       detect(projectPath) {
-        return { engine: "my-engine", engineVersion: "1.2.3" };
+        return { engine: 'my-engine', engineVersion: '1.2.3' };
       },
     },
   ],
   commands: [
     {
-      engine: "my-engine",
+      engine: 'my-engine',
       createCommand(command, subCommands) {
-        if (command === "build") return new MyBuildCommand(command);
-        if (command === "test") return new MyTestCommand(command);
+        if (command === 'build') return new MyBuildCommand(command);
+        if (command === 'test') return new MyTestCommand(command);
         return null;
       },
     },
   ],
   providers: {
-    "my-provider": MyProvider,
+    'my-provider': MyProvider,
   },
 };
 ```

--- a/docs/03-github-cli/04-configuration-and-plugins.mdx
+++ b/docs/03-github-cli/04-configuration-and-plugins.mdx
@@ -84,7 +84,7 @@ The CLI includes built-in plugins for:
 | Godot  | Godot project files                  | Engine command options   |
 | Unreal | `.uproject` files                    | Engine command options   |
 
-External plugins can add new engine providers or replace command behavior without changing the CLI
+External plugins can add new engine support or replace command behavior without changing the CLI
 core.
 
 ## Plugin API

--- a/docs/03-github-cli/04-configuration-and-plugins.mdx
+++ b/docs/03-github-cli/04-configuration-and-plugins.mdx
@@ -7,7 +7,7 @@ slug: /cli/configuration-and-plugins
 
 The `game-ci` CLI can read options from `.game-ci.yml` and load plugins from command-line flags or
 config. Those plugins can add engine detection, build commands, test commands, custom commands,
-options, and remote providers.
+options, and provider-backed job execution.
 
 ## Config File
 
@@ -23,7 +23,7 @@ Options live under `cliOptions`.
 ```yaml
 cliOptions:
   plugin:
-    - '@game-ci/orchestrator-plugin'
+    - "@game-ci/orchestrator-plugin"
   verbose: true
   targetPlatform: StandaloneLinux64
   buildsPath: dist
@@ -35,7 +35,7 @@ camelCase names such as `targetPlatform`, `providerStrategy`, `customImage`, and
 ## Plugin Sources
 
 Plugins can provide engine detectors, build or test command handlers, custom commands, options, and
-remote providers.
+provider implementations.
 
 | Source type      | Example                                  |
 | ---------------- | ---------------------------------------- |
@@ -54,7 +54,7 @@ The Orchestrator ships provider implementations for the public CLI.
 ```bash
 game-ci \
   --plugin @game-ci/orchestrator-plugin \
-  remote run ./my-project \
+  orchestrate ./my-project \
   --provider-strategy aws
 ```
 
@@ -63,7 +63,7 @@ You can also add the plugin to `.game-ci.yml`:
 ```yaml
 cliOptions:
   plugins:
-    - '@game-ci/orchestrator-plugin'
+    - "@game-ci/orchestrator-plugin"
   providerStrategy: local-docker
   targetPlatform: StandaloneLinux64
 ```
@@ -71,7 +71,7 @@ cliOptions:
 Then run:
 
 ```bash
-game-ci remote run ./my-project
+game-ci orchestrate ./my-project
 ```
 
 ## Built-In Engine Support
@@ -94,35 +94,35 @@ commands, test commands, option registration, providers, and an `onLoad` hook.
 
 ```ts
 export default {
-  name: 'my-engine',
-  version: '1.0.0',
+  name: "my-engine",
+  version: "1.0.0",
   engineDetectors: [
     {
-      name: 'my-engine',
+      name: "my-engine",
       detect(projectPath) {
-        return { engine: 'my-engine', engineVersion: '1.2.3' };
+        return { engine: "my-engine", engineVersion: "1.2.3" };
       },
     },
   ],
   commands: [
     {
-      engine: 'my-engine',
+      engine: "my-engine",
       createCommand(command, subCommands) {
-        if (command === 'build') return new MyBuildCommand(command);
-        if (command === 'test') return new MyTestCommand(command);
+        if (command === "build") return new MyBuildCommand(command);
+        if (command === "test") return new MyTestCommand(command);
         return null;
       },
     },
   ],
   providers: {
-    'my-provider': MyProvider,
+    "my-provider": MyProvider,
   },
 };
 ```
 
-Provider plugins register provider strategy names. `game-ci remote run` then creates the provider
-selected by `--provider-strategy`. `game-ci remote build` is kept as a compatibility alias for older
-workflows.
+Provider plugins register provider strategy names. `game-ci orchestrate` then creates the provider
+selected by `--provider-strategy`. `game-ci remote run` and `game-ci remote build` are kept as
+compatibility aliases for older workflows.
 
 ## Local Config Folder
 

--- a/docs/03-github-cli/05-github-action.mdx
+++ b/docs/03-github-cli/05-github-action.mdx
@@ -7,7 +7,8 @@ slug: /cli/github-action
 
 Use `game-ci/cli` as a GitHub Action when you want the public GameCI CLI available inside a
 workflow. The action installs the standalone `game-ci` binary on the runner and can optionally run
-any CLI command in the same step: build, test, custom engine method, remote job, or config command.
+any CLI command in the same step: build, test, custom engine method, provider-backed job, or config
+command.
 
 ```yaml
 jobs:
@@ -68,19 +69,19 @@ Pinning `uses: game-ci/cli@v0.1.0` is preferred for repeatable workflows.
 | `version`           | empty   | CLI release to install, for example `v0.1.0`. Overrides action-ref detection. |
 | `working-directory` | `.`     | Directory where the `game-ci` command runs when `args` is set.                |
 
-## Remote Jobs
+## Orchestrated Jobs
 
-The action can run remote jobs by loading provider plugins, the same as the terminal CLI.
+The action can run provider-backed jobs by loading provider plugins, the same as the terminal CLI.
 
 ```yaml
 - uses: game-ci/cli@v0.1.0
   with:
     args: >-
-      --plugin @game-ci/orchestrator-plugin remote run . --provider-strategy local-docker
+      --plugin @game-ci/orchestrator-plugin orchestrate . --provider-strategy local-docker
       --target-platform StandaloneLinux64
 ```
 
-For provider-specific setup, see [Remote jobs](/docs/cli/remote-builds).
+For provider-specific setup, see [orchestrated jobs](/docs/cli/remote-builds).
 
 ## Platform Support
 

--- a/docs/03-github-cli/index.mdx
+++ b/docs/03-github-cli/index.mdx
@@ -7,8 +7,8 @@ slug: /cli
 
 The `game-ci` CLI is the user-facing command line for running GameCI workflows from a terminal or
 from any CI system. It gives you a high-level API for game automation tasks such as builds, tests,
-custom engine methods, and remote provider jobs. Lower-level engine and provider implementations are
-loaded as plugins.
+custom engine methods, and provider-backed jobs. Lower-level engine and provider implementations
+are loaded as plugins.
 
 Unity is the primary supported package in GameCI, but the CLI itself is not Unity-only. It ships
 with built-in engine detection and engine command implementations for Unity, Godot, and Unreal
@@ -21,7 +21,7 @@ Use this CLI when you want a stable command surface such as:
 game-ci build ./my-project
 game-ci test ./my-project
 game-ci build ./my-unity-project --build-method Company.CI.RunValidation
-game-ci --plugin @game-ci/orchestrator-plugin remote run ./my-project --provider-strategy local-docker
+game-ci --plugin @game-ci/orchestrator-plugin orchestrate ./my-project --provider-strategy local-docker
 game-ci config open
 ```
 
@@ -73,7 +73,7 @@ The CLI has a small core and loads engine, command, and provider behavior throug
 | --------------------- | ------------------------------------------------------------------ |
 | `game-ci build`       | Run the detected engine's build command.                           |
 | `game-ci test`        | Run the detected engine's test command when a plugin provides one. |
-| `game-ci remote run`  | Schedule an engine job through a provider plugin.                  |
+| `game-ci orchestrate` | Schedule an engine job through a provider plugin.                  |
 | `game-ci config open` | Open the local GameCI configuration folder.                        |
 
 The built-in plugins provide:
@@ -85,9 +85,9 @@ The built-in plugins provide:
 | Unreal | `.uproject` files                    | Engine command options   | Requires a licensed Unreal-capable Docker image.                   |
 | Other  | Plugin-defined                       | Plugin-defined commands  | Plugins can add build, test, provider, or custom command behavior. |
 
-Remote providers such as local Docker, AWS, Kubernetes, GitHub Actions dispatch, and custom provider
-executables are registered by provider plugins. The Orchestrator plugin is the intended backend for
-GameCI remote execution.
+Provider types such as local Docker, local system, AWS, Kubernetes, GitHub Actions dispatch, and
+custom provider executables are registered by provider plugins. The Orchestrator plugin is the
+intended backend for GameCI provider-backed execution.
 
 ## First Commands
 
@@ -111,13 +111,13 @@ game-ci build ./my-project --engine unity --engine-version 2022.3.20f1
 
 ## Public CLI vs Orchestrator CLI
 
-| Use case                                        | Recommended entry point                                  |
-| ----------------------------------------------- | -------------------------------------------------------- |
-| Local or CI engine commands with a friendly API | `game-ci` from `game-ci/cli`                             |
-| Remote jobs via provider plugins                | `game-ci remote run` with `@game-ci/orchestrator-plugin` |
-| Provider protocol development                   | Standalone `@game-ci/orchestrator` CLI                   |
-| GitHub Actions workflows with the CLI           | `game-ci/cli` GitHub Action                              |
-| Unity-specific GitHub Actions workflows         | `game-ci/unity-builder` with Orchestrator inputs         |
+| Use case                                        | Recommended entry point                                   |
+| ----------------------------------------------- | --------------------------------------------------------- |
+| Local or CI engine commands with a friendly API | `game-ci` from `game-ci/cli`                              |
+| Provider-backed jobs                            | `game-ci orchestrate` with `@game-ci/orchestrator-plugin` |
+| Provider protocol development                   | Standalone `@game-ci/orchestrator` CLI                    |
+| GitHub Actions workflows with the CLI           | `game-ci/cli` GitHub Action                               |
+| Unity-specific GitHub Actions workflows         | `game-ci/unity-builder` with Orchestrator inputs          |
 
 ## Command Names At A Glance
 
@@ -125,20 +125,23 @@ game-ci build ./my-project --engine unity --engine-version 2022.3.20f1
 | ---------------------- | --------------------------- | -------------------------------------------------------------------------- |
 | `game-ci build`        | Public GameCI CLI           | User-facing local or CI engine builds, including custom Unity methods.     |
 | `game-ci test`         | Public GameCI CLI           | Engine test workflows when the selected engine plugin provides test logic. |
-| `game-ci remote run`   | Public GameCI CLI           | Provider-backed jobs through Orchestrator or another provider plugin.      |
-| `game-ci remote build` | Public GameCI CLI           | Compatibility alias for `game-ci remote run`.                              |
-| `game-ci orchestrate`  | Standalone Orchestrator CLI | Direct low-level Orchestrator provider runs and provider debugging.        |
+| `game-ci orchestrate`  | Public GameCI CLI           | Provider-backed jobs through Orchestrator or another provider plugin.      |
+| `game-ci remote run`   | Public GameCI CLI           | Compatibility alias for `game-ci orchestrate`.                             |
+| `game-ci remote build` | Public GameCI CLI           | Older compatibility alias for `game-ci orchestrate`.                       |
+| `game-ci orchestrate`  | Standalone Orchestrator CLI | Direct Orchestrator provider runs and provider debugging.                  |
 | `game-ci build`        | Standalone Orchestrator CLI | A narrow remote Orchestrator build shortcut, not the public CLI build API. |
 | `game-ci serve`        | Standalone Orchestrator CLI | JSON provider protocol mode for executable provider plugins.               |
 
-If you are reading public CLI docs, prefer `remote run` for provider-backed work. Reach for
-standalone `orchestrate` only when you installed `@game-ci/orchestrator` directly or you are
-debugging Orchestrator/provider behavior outside the public CLI.
+If you are reading public CLI docs, prefer `orchestrate` for provider-backed work. The same verb
+exists in the standalone Orchestrator package, but the package you install determines the option
+surface and plugin behavior. Reach for standalone Orchestrator only when you installed
+`@game-ci/orchestrator` directly or you are debugging Orchestrator/provider behavior outside the
+public CLI.
 
 ## Next Steps
 
 - [Engine commands](/docs/cli/build) - run builds, tests, and custom engine methods
-- [Remote jobs](/docs/cli/remote-builds) - load provider plugins and run remote jobs
+- [Orchestrated jobs](/docs/cli/remote-builds) - load provider plugins and run provider-backed jobs
 - [Configuration and plugins](/docs/cli/configuration-and-plugins) - configure `.game-ci.yml` and
   plugins
 - [GitHub Action](/docs/cli/github-action) - install and run the CLI in GitHub Actions

--- a/docs/03-github-cli/index.mdx
+++ b/docs/03-github-cli/index.mdx
@@ -25,8 +25,9 @@ game-ci --plugin @game-ci/orchestrator-plugin remote run ./my-project --provider
 game-ci config open
 ```
 
-The Orchestrator CLI is still available for advanced or standalone provider work, but most users
-should start with `game-ci`.
+The standalone Orchestrator CLI is still available for advanced or standalone provider work, but
+most users should start with `game-ci` from this CLI. Both binaries are named `game-ci` after
+installation, so the command set you see depends on which package installed the binary.
 
 ## Install
 
@@ -117,6 +118,22 @@ game-ci build ./my-project --engine unity --engine-version 2022.3.20f1
 | Provider protocol development                   | Standalone `@game-ci/orchestrator` CLI                   |
 | GitHub Actions workflows with the CLI           | `game-ci/cli` GitHub Action                              |
 | Unity-specific GitHub Actions workflows         | `game-ci/unity-builder` with Orchestrator inputs         |
+
+## Command Names At A Glance
+
+| Command                | Where it exists             | Use it for                                                                 |
+| ---------------------- | --------------------------- | -------------------------------------------------------------------------- |
+| `game-ci build`        | Public GameCI CLI           | User-facing local or CI engine builds, including custom Unity methods.     |
+| `game-ci test`         | Public GameCI CLI           | Engine test workflows when the selected engine plugin provides test logic. |
+| `game-ci remote run`   | Public GameCI CLI           | Provider-backed jobs through Orchestrator or another provider plugin.      |
+| `game-ci remote build` | Public GameCI CLI           | Compatibility alias for `game-ci remote run`.                              |
+| `game-ci orchestrate`  | Standalone Orchestrator CLI | Direct low-level Orchestrator provider runs and provider debugging.        |
+| `game-ci build`        | Standalone Orchestrator CLI | A narrow remote Orchestrator build shortcut, not the public CLI build API. |
+| `game-ci serve`        | Standalone Orchestrator CLI | JSON provider protocol mode for executable provider plugins.               |
+
+If you are reading public CLI docs, prefer `remote run` for provider-backed work. Reach for
+standalone `orchestrate` only when you installed `@game-ci/orchestrator` directly or you are
+debugging Orchestrator/provider behavior outside the public CLI.
 
 ## Next Steps
 

--- a/docs/03-github-orchestrator/01-introduction-to-orchestrator/01-introduction.mdx
+++ b/docs/03-github-orchestrator/01-introduction-to-orchestrator/01-introduction.mdx
@@ -92,7 +92,7 @@ for provider development, debugging, and direct backend usage.
 | Decide whether you need Orchestrator | [GameCI vs Orchestrator](game-ci-vs-orchestrator)                         |
 | Run an engine build on AWS or K8s    | [Getting Started](getting-started)                                        |
 | Run from a terminal                  | [GameCI CLI](/docs/cli)                                                   |
-| Choose a provider                    | [Providers](../providers/overview)                                        |
+| Choose a provider type               | [Provider Types](../providers/overview)                                   |
 | Tune cache behavior                  | [Caching](../advanced-topics/caching)                                     |
 | Keep whole workspaces warm           | [Retained Workspaces](../advanced-topics/caching#retained-workspaces)     |
 | Stream jobs to warm runners          | [Standalone Streaming Hot Runner](../advanced-topics/hot-runner-protocol) |
@@ -100,7 +100,7 @@ for provider development, debugging, and direct backend usage.
 | Add custom build steps               | [Hooks](../advanced-topics/hooks/container-hooks)                         |
 | Look up inputs                       | [API Reference](../api-reference)                                         |
 
-## Providers
+## Provider Types
 
 | Provider                                  | Description                                              |
 | ----------------------------------------- | -------------------------------------------------------- |

--- a/docs/03-github-orchestrator/01-introduction-to-orchestrator/03-getting-started.mdx
+++ b/docs/03-github-orchestrator/01-introduction-to-orchestrator/03-getting-started.mdx
@@ -84,7 +84,7 @@ See the [Local Docker provider page](../providers/local-docker) for details.
   </TabItem>
 </Tabs>
 
-See [Providers](../providers/overview) for the full list and detailed setup guides.
+See [Provider Types](../providers/overview) for the full list and detailed setup guides.
 
 ## GitHub Actions
 
@@ -162,7 +162,7 @@ The standalone Orchestrator CLI remains available for provider development and d
 
 ## Next Steps
 
-- [Provider setup guides](../providers/overview) - configure your cloud credentials
+- [Provider type setup guides](../providers/overview) - configure your cloud credentials
 - [API Reference](../api-reference) - full parameter documentation
 - [Examples](examples/github-actions) - more workflow examples
 - [GameCI CLI](/docs/cli) - public command-line interface

--- a/docs/03-github-orchestrator/01-introduction-to-orchestrator/03-getting-started.mdx
+++ b/docs/03-github-orchestrator/01-introduction-to-orchestrator/03-getting-started.mdx
@@ -1,5 +1,5 @@
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
 
 # Getting Started
 
@@ -152,7 +152,7 @@ export AWS_SECRET_ACCESS_KEY="..."
 ```bash
 game-ci \
   --plugin @game-ci/orchestrator-plugin \
-  remote run ./my-project \
+  orchestrate ./my-project \
   --provider-strategy aws \
   --target-platform StandaloneLinux64
 ```

--- a/docs/03-github-orchestrator/01-introduction-to-orchestrator/03-getting-started.mdx
+++ b/docs/03-github-orchestrator/01-introduction-to-orchestrator/03-getting-started.mdx
@@ -1,5 +1,5 @@
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # Getting Started
 

--- a/docs/03-github-orchestrator/01-introduction-to-orchestrator/04-examples/01-command-line.mdx
+++ b/docs/03-github-orchestrator/01-introduction-to-orchestrator/04-examples/01-command-line.mdx
@@ -1,8 +1,8 @@
 # Command Line
 
-Use the public `game-ci` CLI for command-line builds. Orchestrator is loaded as a provider plugin,
-so the user-facing command remains `game-ci remote run` while provider-specific behavior stays in
-the Orchestrator package.
+Use the public `game-ci` CLI for command-line builds and other engine automation. Orchestrator is
+loaded as a provider plugin, so the user-facing command is `game-ci orchestrate` while
+provider-specific behavior stays in the Orchestrator package.
 
 ## Install GameCI CLI
 
@@ -28,7 +28,7 @@ The standalone Orchestrator CLI can also be installed directly for provider deve
 ```bash
 game-ci \
   --plugin @game-ci/orchestrator-plugin \
-  remote run ./my-project \
+  orchestrate ./my-project \
   --provider-strategy local-docker \
   --target-platform StandaloneLinux64
 ```
@@ -38,7 +38,7 @@ game-ci \
 ```bash
 game-ci \
   --plugin @game-ci/orchestrator-plugin \
-  remote run ./my-project \
+  orchestrate ./my-project \
   --provider-strategy aws \
   --target-platform StandaloneLinux64 \
   --git-private-token $GIT_TOKEN
@@ -49,7 +49,7 @@ game-ci \
 ```bash
 game-ci \
   --plugin @game-ci/orchestrator-plugin \
-  remote run ./my-project \
+  orchestrate ./my-project \
   --provider-strategy k8s \
   --target-platform StandaloneLinux64 \
   --git-private-token $GIT_TOKEN
@@ -87,7 +87,7 @@ Avoid long CLI flags for credentials by using environment variables or the
 ```bash
 game-ci \
   --plugin @game-ci/orchestrator-plugin \
-  remote run ./my-project \
+  orchestrate ./my-project \
   --provider-strategy aws \
   --target-platform StandaloneLinux64 \
   --pull-input-list UNITY_EMAIL,UNITY_SERIAL,UNITY_PASSWORD \
@@ -97,5 +97,5 @@ game-ci \
 ## Further Reading
 
 - [GameCI CLI](/docs/cli) - public command-line interface
-- [Remote jobs](/docs/cli/remote-builds) - provider plugin usage
+- [Orchestrated jobs](/docs/cli/remote-builds) - provider plugin usage
 - [Standalone Orchestrator CLI](../../cli/getting-started) - lower-level Orchestrator entry point

--- a/docs/03-github-orchestrator/01-introduction-to-orchestrator/04-examples/02-github-actions.mdx
+++ b/docs/03-github-orchestrator/01-introduction-to-orchestrator/04-examples/02-github-actions.mdx
@@ -344,7 +344,7 @@ rclone, Steam).
 ## 🔗 Reference
 
 - [API Reference](../../api-reference) - full list of all parameters
-- [Providers](../../providers/overview) - setup guides for each provider
+- [Provider Types](../../providers/overview) - setup guides for each provider type
 - [Secrets](../../secrets) - how credentials are transferred to build containers
 - [Real-world pipeline](https://github.com/game-ci/unity-builder/blob/main/.github/workflows/orchestrator-integrity.yml)
   - Game CI's own Orchestrator test pipeline

--- a/docs/03-github-orchestrator/05-providers/01-overview.mdx
+++ b/docs/03-github-orchestrator/05-providers/01-overview.mdx
@@ -1,7 +1,11 @@
-# Providers
+# Provider Types
 
-A **provider** is the backend that Orchestrator uses to run your builds. You choose a provider by
-setting the `providerStrategy` parameter.
+Provider types are the execution backends Orchestrator can target. They are not the same thing as
+engine plugins: engine plugins describe how to run a Unity, Godot, Unreal, or custom-engine
+workload, while provider types describe where that workload runs.
+
+A **provider type** is the backend that Orchestrator uses to run your jobs. You choose a provider
+type by setting the `providerStrategy` parameter.
 
 ```mermaid
 graph LR

--- a/docs/03-github-orchestrator/05-providers/_category_.yaml
+++ b/docs/03-github-orchestrator/05-providers/_category_.yaml
@@ -1,5 +1,5 @@
 ---
 position: 5.0
-label: Providers
+label: Provider Types
 collapsible: true
 collapsed: true

--- a/docs/03-github-orchestrator/07-advanced-topics/10-build-services.mdx
+++ b/docs/03-github-orchestrator/07-advanced-topics/10-build-services.mdx
@@ -45,7 +45,7 @@ For command-line usage, pass the same YAML as `--custom-job`:
 ```bash
 game-ci \
   --plugin @game-ci/orchestrator-plugin \
-  remote run ./my-project \
+  orchestrate ./my-project \
   --provider-strategy local-docker \
   --custom-job '- name: smoke
   image: ubuntu:24.04

--- a/docs/03-github-orchestrator/08-cli/01-getting-started.mdx
+++ b/docs/03-github-orchestrator/08-cli/01-getting-started.mdx
@@ -9,7 +9,8 @@ useful for provider development, debugging, and environments that need the orche
 without installing the public `game-ci` CLI.
 
 Most users should use the public [GameCI CLI](/docs/cli). The public CLI exposes the higher-level
-user API and can load Orchestrator as a provider plugin.
+user API and can load Orchestrator as a provider plugin. The standalone Orchestrator binary also
+uses the executable name `game-ci`, but it exposes a different command surface.
 
 ## When To Use It
 
@@ -19,6 +20,22 @@ user API and can load Orchestrator as a provider plugin.
 | Remote jobs through a friendly CLI         | `game-ci remote run` with the Orchestrator plugin |
 | GitHub Actions Unity builds                | `game-ci/unity-builder@v4`                        |
 | Provider protocol development or debugging | Standalone Orchestrator CLI                       |
+
+## Command Surface
+
+| Standalone command          | Purpose                                                                     |
+| --------------------------- | --------------------------------------------------------------------------- |
+| `game-ci orchestrate`       | Full direct Orchestrator provider command for remote, Docker, or host runs. |
+| `game-ci build`             | Narrow remote build shortcut for Orchestrator-compatible parameters.        |
+| `game-ci orchestrate cache` | Cache inspection helpers under the direct Orchestrator command.             |
+| `game-ci serve`             | JSON provider protocol mode used by executable provider integrations.       |
+| `game-ci activate`          | Unity license preflight helper.                                             |
+| `game-ci status`            | Local environment diagnostics.                                              |
+| `game-ci version`           | Print standalone Orchestrator CLI version information.                      |
+| `game-ci update`            | Update the standalone Orchestrator binary.                                  |
+
+The public CLI commands `game-ci remote run` and `game-ci test` are not standalone Orchestrator
+commands. Use the public CLI when you want that higher-level command model.
 
 ## Install
 
@@ -40,7 +57,7 @@ Pre-built binaries are available on the
 ## Example
 
 ```bash
-game-ci build \
+game-ci orchestrate \
   --target-platform StandaloneLinux64 \
   --provider-strategy aws
 ```
@@ -70,5 +87,5 @@ an optional plugin. You do not need to install the standalone Orchestrator CLI i
 ## Next Steps
 
 - [Public GameCI CLI](/docs/cli)
-- [Providers](../providers/overview)
+- [Provider Types](../providers/overview)
 - [CLI provider protocol](../providers/cli-provider-protocol)

--- a/docs/03-github-orchestrator/08-cli/01-getting-started.mdx
+++ b/docs/03-github-orchestrator/08-cli/01-getting-started.mdx
@@ -14,12 +14,12 @@ uses the executable name `game-ci`, but it exposes a different command surface.
 
 ## When To Use It
 
-| Use case                                   | Entry point                                       |
-| ------------------------------------------ | ------------------------------------------------- |
-| General local or CI commands               | [GameCI CLI](/docs/cli)                           |
-| Remote jobs through a friendly CLI         | `game-ci remote run` with the Orchestrator plugin |
-| GitHub Actions Unity builds                | `game-ci/unity-builder@v4`                        |
-| Provider protocol development or debugging | Standalone Orchestrator CLI                       |
+| Use case                                    | Entry point                                        |
+| ------------------------------------------- | -------------------------------------------------- |
+| General local or CI commands                | [GameCI CLI](/docs/cli)                            |
+| Provider-backed jobs through a friendly CLI | `game-ci orchestrate` with the Orchestrator plugin |
+| GitHub Actions Unity builds                 | `game-ci/unity-builder@v4`                         |
+| Provider protocol development or debugging  | Standalone Orchestrator CLI                        |
 
 ## Command Surface
 
@@ -34,8 +34,9 @@ uses the executable name `game-ci`, but it exposes a different command surface.
 | `game-ci version`           | Print standalone Orchestrator CLI version information.                      |
 | `game-ci update`            | Update the standalone Orchestrator binary.                                  |
 
-The public CLI commands `game-ci remote run` and `game-ci test` are not standalone Orchestrator
-commands. Use the public CLI when you want that higher-level command model.
+The public CLI commands `game-ci orchestrate` and `game-ci test` are not standalone Orchestrator
+commands, even though standalone Orchestrator also exposes an `orchestrate` verb. Use the public CLI
+when you want the higher-level command model and plugin loading behavior.
 
 ## Install
 
@@ -67,7 +68,7 @@ This command talks directly to the Orchestrator package. The public CLI equivale
 ```bash
 game-ci \
   --plugin @game-ci/orchestrator-plugin \
-  remote run ./my-project \
+  orchestrate ./my-project \
   --provider-strategy aws \
   --target-platform StandaloneLinux64
 ```

--- a/docs/03-github-orchestrator/08-cli/02-build-command.mdx
+++ b/docs/03-github-orchestrator/08-cli/02-build-command.mdx
@@ -11,7 +11,7 @@ from `game-ci/cli`.
 
 For normal user-facing local builds, tests, and custom Unity methods, use the public
 [`game-ci build`](/docs/cli/build) and [`game-ci test`](/docs/cli/build) commands. For general
-provider-backed jobs from the public CLI, use [`game-ci remote run`](/docs/cli/remote-builds).
+provider-backed jobs from the public CLI, use [`game-ci orchestrate`](/docs/cli/remote-builds).
 
 Use standalone `game-ci build` only when you intentionally installed Orchestrator directly and want
 a short command for a standard remote build. Use [`game-ci orchestrate`](orchestrate-command) when

--- a/docs/03-github-orchestrator/08-cli/02-build-command.mdx
+++ b/docs/03-github-orchestrator/08-cli/02-build-command.mdx
@@ -4,10 +4,19 @@ sidebar_position: 2
 
 # Build Command
 
-The standalone Orchestrator `build` command runs a local engine build with Orchestrator-compatible
-parameters. Unity is the default and primary supported package, but engine configuration is explicit
-so built-in or custom engine providers can supply cache folders and lifecycle behavior. The CLI is
-provided by the [`@game-ci/orchestrator`](https://github.com/game-ci/orchestrator) package.
+The standalone Orchestrator `build` command is a narrow shortcut for running a standard
+Orchestrator-managed build through a remote provider. It exists on the
+[`@game-ci/orchestrator`](https://github.com/game-ci/orchestrator) CLI, not on the public GameCI CLI
+from `game-ci/cli`.
+
+For normal user-facing local builds, tests, and custom Unity methods, use the public
+[`game-ci build`](/docs/cli/build) and [`game-ci test`](/docs/cli/build) commands. For general
+provider-backed jobs from the public CLI, use [`game-ci remote run`](/docs/cli/remote-builds).
+
+Use standalone `game-ci build` only when you intentionally installed Orchestrator directly and want
+a short command for a standard remote build. Use [`game-ci orchestrate`](orchestrate-command) when
+you need local-docker, local-system, custom jobs, hooks, cache helpers, or deeper provider
+debugging.
 
 ```bash
 game-ci build [options]
@@ -136,15 +145,17 @@ game-ci build \
 
 ## Provider Strategy
 
-By default, the `build` command runs locally. You can redirect execution to a remote orchestrator
-provider:
+The `build` command must run through an Orchestrator provider. Although the flag default is `local`
+internally, standalone local builds are not handled here; the command will ask you to use
+unity-builder or the public CLI for local execution.
 
-| Flag                  | Default | Description                                  |
-| --------------------- | ------- | -------------------------------------------- |
-| `--provider-strategy` | `local` | Execution strategy: `local`, `k8s`, or `aws` |
+| Flag                  | Default | Description                                      |
+| --------------------- | ------- | ------------------------------------------------ |
+| `--provider-strategy` | `local` | Set to a remote strategy such as `aws` or `k8s`. |
 
-When set to anything other than `local`, the build is handed off to the orchestrator. See
-[Standalone Orchestrator Command](orchestrate-command) for cloud-specific options.
+For local Docker or host execution through Orchestrator, use
+`game-ci orchestrate --provider-strategy local-docker` or
+`game-ci orchestrate --provider-strategy local-system` instead.
 
 ## Output
 

--- a/docs/03-github-orchestrator/08-cli/03-orchestrate-command.mdx
+++ b/docs/03-github-orchestrator/08-cli/03-orchestrate-command.mdx
@@ -7,7 +7,7 @@ sidebar_position: 3
 The standalone Orchestrator CLI command is named `orchestrate`. It is a lower-level provider entry
 point for running engine work on local Docker, local system, or cloud infrastructure. Unity is the
 primary built-in package, and engine plugins can adapt the workload for other engines. For the
-public GameCI CLI, use [`game-ci remote run`](/docs/cli/remote-builds) instead.
+public GameCI CLI, use [`game-ci orchestrate`](/docs/cli/remote-builds) with a provider plugin.
 
 `orchestrate` provisions an execution environment, syncs your project, runs the requested workload,
 and retrieves artifacts.
@@ -18,21 +18,23 @@ game-ci orchestrate [options]
 
 This is the standalone CLI equivalent of using `game-ci/unity-builder` with a `providerStrategy` in
 GitHub Actions. It is mainly useful for provider development, debugging, and direct Orchestrator
-usage.
+usage. The public CLI uses the same command verb, but it loads providers through the public plugin
+API and keeps the higher-level GameCI command model.
 
 ## When To Use This Command
 
 | Situation                                                   | Recommended command                                    |
 | ----------------------------------------------------------- | ------------------------------------------------------ |
-| Public CLI remote job with a friendly command surface       | `game-ci remote run` from `game-ci/cli`                |
+| Public CLI provider-backed job with a friendly surface      | `game-ci orchestrate` from `game-ci/cli`               |
 | Standalone Orchestrator standard remote build shortcut      | `game-ci build --provider-strategy aws` or `k8s`       |
 | Standalone Orchestrator direct provider run                 | `game-ci orchestrate`                                  |
 | Standalone local Docker or local host Orchestrator behavior | `game-ci orchestrate --provider-strategy local-docker` |
 | Custom job YAML, pre/post steps, cache key testing          | `game-ci orchestrate`                                  |
 | Executable provider protocol serving another CLI            | `game-ci serve`                                        |
 
-In short: `remote run` is the public API, `orchestrate` is the direct Orchestrator API, and
-standalone `build` is only a convenience shortcut for a standard remote build.
+In short: public `orchestrate` is the friendly plugin-backed GameCI CLI API, standalone
+`orchestrate` is the direct Orchestrator API, and standalone `build` is only a convenience shortcut
+for a standard remote build.
 
 ## Required Options
 

--- a/docs/03-github-orchestrator/08-cli/03-orchestrate-command.mdx
+++ b/docs/03-github-orchestrator/08-cli/03-orchestrate-command.mdx
@@ -5,8 +5,9 @@ sidebar_position: 3
 # Standalone Orchestrator Command
 
 The standalone Orchestrator CLI command is named `orchestrate`. It is a lower-level provider entry
-point for running Unity work on local Docker, local system, or cloud infrastructure. For the public
-GameCI CLI, use [`game-ci remote run`](/docs/cli/remote-builds) instead.
+point for running engine work on local Docker, local system, or cloud infrastructure. Unity is the
+primary built-in package, and engine plugins can adapt the workload for other engines. For the
+public GameCI CLI, use [`game-ci remote run`](/docs/cli/remote-builds) instead.
 
 `orchestrate` provisions an execution environment, syncs your project, runs the requested workload,
 and retrieves artifacts.
@@ -19,15 +20,29 @@ This is the standalone CLI equivalent of using `game-ci/unity-builder` with a `p
 GitHub Actions. It is mainly useful for provider development, debugging, and direct Orchestrator
 usage.
 
+## When To Use This Command
+
+| Situation                                                   | Recommended command                                    |
+| ----------------------------------------------------------- | ------------------------------------------------------ |
+| Public CLI remote job with a friendly command surface       | `game-ci remote run` from `game-ci/cli`                |
+| Standalone Orchestrator standard remote build shortcut      | `game-ci build --provider-strategy aws` or `k8s`       |
+| Standalone Orchestrator direct provider run                 | `game-ci orchestrate`                                  |
+| Standalone local Docker or local host Orchestrator behavior | `game-ci orchestrate --provider-strategy local-docker` |
+| Custom job YAML, pre/post steps, cache key testing          | `game-ci orchestrate`                                  |
+| Executable provider protocol serving another CLI            | `game-ci serve`                                        |
+
+In short: `remote run` is the public API, `orchestrate` is the direct Orchestrator API, and
+standalone `build` is only a convenience shortcut for a standard remote build.
+
 ## Required Options
 
 | Flag                | Description                                      |
 | ------------------- | ------------------------------------------------ |
 | `--target-platform` | Build target platform (e.g. `StandaloneLinux64`) |
 
-## Provider Selection
+## Provider Type Selection
 
-Choose where your build runs with the `--provider-strategy` flag:
+Choose where the job runs with the `--provider-strategy` flag:
 
 | Provider     | Value          | Description                            |
 | ------------ | -------------- | -------------------------------------- |
@@ -151,4 +166,4 @@ game-ci orchestrate \
 - [Getting Started](getting-started) - installation and first build
 - [Build Command](build-command) - local Docker builds
 - [API Reference](../api-reference) - full parameter reference
-- [Providers](../providers/overview) - provider-specific setup guides
+- [Provider Types](../providers/overview) - provider-specific setup guides

--- a/docs/03-github-orchestrator/08-cli/04-other-commands.mdx
+++ b/docs/03-github-orchestrator/08-cli/04-other-commands.mdx
@@ -4,9 +4,9 @@ sidebar_position: 4
 
 # Other Commands
 
-Beyond `build` and the standalone `orchestrate` provider command, the CLI provides commands for
-license management, cache operations, environment diagnostics, version information, and
-self-updating.
+Beyond `build` and the standalone `orchestrate` provider command, the standalone Orchestrator CLI
+provides commands for license preflight, cache inspection, provider protocol serving, environment
+diagnostics, version information, and self-updating.
 
 ## activate
 
@@ -50,13 +50,13 @@ game-ci activate
 game-ci activate --unity-licensing-server http://license-server:8080
 ```
 
-## cache
+## orchestrate cache
 
-Manage build caches. Caches store the Unity Library folder and other intermediate artifacts to speed
-up subsequent builds.
+Manage build caches under the direct Orchestrator command. Caches store the Unity Library folder or
+engine-specific cache folders and other intermediate artifacts to speed up subsequent builds.
 
 ```bash
-game-ci cache <action> [options]
+game-ci orchestrate cache <action> [options]
 ```
 
 The `<action>` positional argument is required and must be one of: `list`, `restore`, or `clear`.
@@ -66,7 +66,7 @@ The `<action>` positional argument is required and must be one of: `list`, `rest
 List cache status, including Library folder presence and any cache archives:
 
 ```bash
-game-ci cache list
+game-ci orchestrate cache list
 ```
 
 Output includes Library folder path, entry count, last-modified timestamp, and key subdirectory
@@ -77,7 +77,7 @@ status (PackageCache, ScriptAssemblies, ShaderCache, Bee).
 Check for available cache archives to restore:
 
 ```bash
-game-ci cache restore --cache-dir ./my-cache
+game-ci orchestrate cache restore --cache-dir ./my-cache
 ```
 
 ### cache clear
@@ -85,7 +85,7 @@ game-ci cache restore --cache-dir ./my-cache
 Remove cache archive files:
 
 ```bash
-game-ci cache clear
+game-ci orchestrate cache clear
 ```
 
 ### Cache Flags
@@ -94,6 +94,31 @@ game-ci cache clear
 | ---------------- | --------- | ------------------------------------------------------------------ |
 | `--cache-dir`    | _(empty)_ | Path to the cache directory (defaults to `<project-path>/Library`) |
 | `--project-path` | `.`       | Path to the Unity project                                          |
+
+## serve
+
+Run Orchestrator as a JSON provider protocol server. This is primarily for executable provider
+integrations with the public GameCI CLI, not for day-to-day user workflows.
+
+```bash
+echo '{"command":"list-resources","params":{}}' | game-ci serve --provider-strategy aws
+```
+
+`serve` reads one JSON request from stdin, dispatches it to the selected provider, and writes one
+JSON response to stdout. Logs are written to stderr so callers can separate machine-readable
+responses from human-readable output.
+
+Supported protocol commands include:
+
+| Protocol command   | Purpose                                       |
+| ------------------ | --------------------------------------------- |
+| `setup-workflow`   | Prepare provider resources for a workflow.    |
+| `cleanup-workflow` | Clean up provider resources after a workflow. |
+| `run-task`         | Run a task in the selected provider.          |
+| `garbage-collect`  | Remove old provider/cache resources.          |
+| `list-resources`   | List provider resources.                      |
+| `list-workflow`    | List workflow state.                          |
+| `watch-workflow`   | Stream or poll workflow output.               |
 
 ## status
 
@@ -176,7 +201,8 @@ These flags are available on all commands:
 # Get help for any command
 game-ci build --help
 game-ci orchestrate --help
-game-ci cache --help
+game-ci orchestrate cache --help
+game-ci serve --help
 ```
 
 ## See Also


### PR DESCRIPTION
## Summary
- make `game-ci orchestrate` the documented public CLI command for provider-backed jobs
- keep `game-ci remote run` and `game-ci remote build` documented only as compatibility aliases
- clarify that standalone Orchestrator also has an `orchestrate` verb, but with the direct Orchestrator command surface
- keep the Orchestrator section label as Provider Types and retain `serve` / `orchestrate cache` guidance

## Verification
- `node_modules/.bin/prettier --write` on changed docs
- `yarn build`