### PR TITLE
fix: remove conflict markers from CLI remote builds docs

### DIFF
--- a/docs/03-github-cli/03-remote-builds.mdx
+++ b/docs/03-github-cli/03-remote-builds.mdx
@@ -20,8 +20,6 @@ model.
 The CLI owns the high-level command shape. Providers own infrastructure-specific options and job
 execution behavior.
 
-<<<<<<< HEAD
-
 ## Public CLI vs Standalone Orchestrator
 
 Use `game-ci orchestrate` from the public CLI for normal provider-backed jobs. It keeps the command
@@ -36,27 +34,8 @@ package determines the command surface.
 | ------------------------------------------------------ | ------------------------------------ |
 | Friendly public CLI command for builds, tests, or jobs | `game-ci orchestrate`                |
 | Backwards-compatible old public CLI command names      | `game-ci remote run`, `remote build` |
-
-=======
-
-## Remote Run vs Standalone Orchestrate
-
-Use `game-ci remote run` from the public CLI for normal remote jobs. It keeps the command model
-engine-oriented and lets provider plugins add infrastructure details.
-
-The standalone Orchestrator package also installs a `game-ci orchestrate` command. That command is a
-direct, lower-level Orchestrator entry point for provider development, debugging, and environments
-that intentionally run Orchestrator without the public CLI. It is not the preferred public CLI
-command.
-
-| Need                                                   | Use                    |
-| ------------------------------------------------------ | ---------------------- |
-| Friendly public CLI command for builds, tests, or jobs | `game-ci remote run`   |
-| Backwards-compatible old remote command name           | `game-ci remote build` |
-
-> > > > > > > origin/docs/unity-reliability-guide
-> > > > > > > | Direct standalone Orchestrator provider execution | `game-ci orchestrate` |
-> > > > > > > | Executable provider protocol integration with GameCI CLI | `game-ci serve` in the provider tool |
+| Direct standalone Orchestrator provider execution      | `game-ci orchestrate`                |
+| Executable provider protocol integration               | `game-ci serve` in the provider tool |
 
 ## Orchestrator Plugin
 
@@ -86,12 +65,7 @@ Available Orchestrator provider types include:
 | Remote PowerShell | `remote-powershell` | Run on a remote Windows host.                  |
 | Ansible           | `ansible`           | Run through an Ansible inventory and playbook. |
 | CLI protocol      | `cli`               | Delegate to a custom provider executable.      |
-
-# <<<<<<< HEAD
-
-| Config-defined | `config:<path>` | Map lifecycle commands from YAML or JSON. |
-
-> > > > > > > origin/docs/unity-reliability-guide
+| Config-defined    | `config:<path>`     | Map lifecycle commands from YAML or JSON.      |
 
 ## Local Docker
 
@@ -198,7 +172,7 @@ configuration files:
 ```bash
 game-ci \
   --plugin @game-ci/orchestrator-plugin \
-  remote run ./my-project \
+  orchestrate ./my-project \
   --provider-strategy config:./.game-ci/providers/local-shell.yml
 ```
 


### PR DESCRIPTION
## Summary

- remove unresolved merge conflict markers from `/docs/cli/remote-builds`
- keep the current `game-ci orchestrate` guidance
- restore the config-defined provider row and update the example command to `orchestrate`

## Validation

- `rg -n "<<<<<<<|=======|>>>>>>>" .`
- `yarn oxfmt --check docs/03-github-cli/03-remote-builds.mdx`
- `yarn build`