### PR TITLE
docs: combined orchestrator + CLI + Unity-logs documentation updates (May 2026)

### DIFF
--- a/docs/03-github-cli/03-remote-builds.mdx
+++ b/docs/03-github-cli/03-remote-builds.mdx
@@ -20,8 +20,6 @@ model.
 The CLI owns the high-level command shape. Providers own infrastructure-specific options and job
 execution behavior.
 
-<<<<<<< HEAD
-
 ## Public CLI vs Standalone Orchestrator
 
 Use `game-ci orchestrate` from the public CLI for normal provider-backed jobs. It keeps the command
@@ -36,27 +34,8 @@ package determines the command surface.
 | ------------------------------------------------------ | ------------------------------------ |
 | Friendly public CLI command for builds, tests, or jobs | `game-ci orchestrate`                |
 | Backwards-compatible old public CLI command names      | `game-ci remote run`, `remote build` |
-
-=======
-
-## Remote Run vs Standalone Orchestrate
-
-Use `game-ci remote run` from the public CLI for normal remote jobs. It keeps the command model
-engine-oriented and lets provider plugins add infrastructure details.
-
-The standalone Orchestrator package also installs a `game-ci orchestrate` command. That command is a
-direct, lower-level Orchestrator entry point for provider development, debugging, and environments
-that intentionally run Orchestrator without the public CLI. It is not the preferred public CLI
-command.
-
-| Need                                                   | Use                    |
-| ------------------------------------------------------ | ---------------------- |
-| Friendly public CLI command for builds, tests, or jobs | `game-ci remote run`   |
-| Backwards-compatible old remote command name           | `game-ci remote build` |
-
-> > > > > > > origin/docs/unity-reliability-guide
-> > > > > > > | Direct standalone Orchestrator provider execution | `game-ci orchestrate` |
-> > > > > > > | Executable provider protocol integration with GameCI CLI | `game-ci serve` in the provider tool |
+| Direct standalone Orchestrator provider execution      | `game-ci orchestrate`                |
+| Executable provider protocol integration               | `game-ci serve` in the provider tool |
 
 ## Orchestrator Plugin
 
@@ -86,12 +65,7 @@ Available Orchestrator provider types include:
 | Remote PowerShell | `remote-powershell` | Run on a remote Windows host.                  |
 | Ansible           | `ansible`           | Run through an Ansible inventory and playbook. |
 | CLI protocol      | `cli`               | Delegate to a custom provider executable.      |
-
-# <<<<<<< HEAD
-
-| Config-defined | `config:<path>` | Map lifecycle commands from YAML or JSON. |
-
-> > > > > > > origin/docs/unity-reliability-guide
+| Config-defined    | `config:<path>`     | Map lifecycle commands from YAML or JSON.      |
 
 ## Local Docker
 
@@ -198,7 +172,7 @@ configuration files:
 ```bash
 game-ci \
   --plugin @game-ci/orchestrator-plugin \
-  remote run ./my-project \
+  orchestrate ./my-project \
   --provider-strategy config:./.game-ci/providers/local-shell.yml
 ```
 

--- a/docs/03-github-orchestrator/07-advanced-topics/01-caching.mdx
+++ b/docs/03-github-orchestrator/07-advanced-topics/01-caching.mdx
@@ -361,13 +361,13 @@ write through the hardlink to canonical bytes, corrupting the canonical store fo
 
 The default classifier targets Unity's Library structure:
 
-| Subdirectory | Strategy | Why |
-|---|---|---|
-| `PackageCache/<package>@<hash>/` | Directory junction | Unity treats packages as immutable; new version = new `@<hash>` directory |
-| `ScriptAssemblies/`, `Artifacts/`, `BurstCache/`, `Bee/artifacts/`, `MetadataGenerator/`, `ShaderCache/`, `StateCache/`, `UIBuilder/`, `HDRPLibrary/` | Hardlink | Roslyn, Bee, AssetDatabase v2 all use write-temp-then-rename |
-| `PackageManager/projectResolution.json`, `PackageManager/ProjectCache`, `Bee/*.dag`, `Bee/*.dag.outputdata`, `Bee/*-inputdata.json`, `LastSceneManagerSetup.txt` | Per-runner copy | Contain absolute workspace paths; need cross-runner repair |
-| `AnnotationManager`, `EditorOnly`, `EditorUserBuildSettings.asset`, `EditorUserSettings.asset`, `CurrentLayout-*.dwlt` | Skip | Editor session state; not part of the build cache |
-| (default) | Hardlink | Conservative default for unknown subtrees |
+| Subdirectory                                                                                                                                                     | Strategy           | Why                                                                       |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ------------------------------------------------------------------------- |
+| `PackageCache/<package>@<hash>/`                                                                                                                                 | Directory junction | Unity treats packages as immutable; new version = new `@<hash>` directory |
+| `ScriptAssemblies/`, `Artifacts/`, `BurstCache/`, `Bee/artifacts/`, `MetadataGenerator/`, `ShaderCache/`, `StateCache/`, `UIBuilder/`, `HDRPLibrary/`            | Hardlink           | Roslyn, Bee, AssetDatabase v2 all use write-temp-then-rename              |
+| `PackageManager/projectResolution.json`, `PackageManager/ProjectCache`, `Bee/*.dag`, `Bee/*.dag.outputdata`, `Bee/*-inputdata.json`, `LastSceneManagerSetup.txt` | Per-runner copy    | Contain absolute workspace paths; need cross-runner repair                |
+| `AnnotationManager`, `EditorOnly`, `EditorUserBuildSettings.asset`, `EditorUserSettings.asset`, `CurrentLayout-*.dwlt`                                           | Skip               | Editor session state; not part of the build cache                         |
+| (default)                                                                                                                                                        | Hardlink           | Conservative default for unknown subtrees                                 |
 
 For non-Unity engines, override the classifier with `canonicalCacheClassifier`:
 
@@ -392,10 +392,10 @@ For non-Unity engines, override the classifier with `canonicalCacheClassifier`:
   with:
     localCacheEnabled: true
     localCacheMode: canonical-overlay
-    canonicalCacheRoot: D:/CI/Canonical    # falls back to <localCacheRoot>/canonical
-    canonicalCacheVersionRetention: 2      # keep last 2 SHA versions per key
-    cacheMaterialize: prepared             # sub-second hydration
-    cacheSentinelCanary: true              # defense-in-depth
+    canonicalCacheRoot: D:/CI/Canonical # falls back to <localCacheRoot>/canonical
+    canonicalCacheVersionRetention: 2 # keep last 2 SHA versions per key
+    cacheMaterialize: prepared # sub-second hydration
+    cacheSentinelCanary: true # defense-in-depth
 ```
 
 ### Sub-second hydration with `prepared` materialize
@@ -417,28 +417,28 @@ through to live materialize.
 
 ### Failure modes and self-heal
 
-| Scenario | Behaviour |
-|---|---|
-| Cancel during canonical publish | Orphan `<sha>-staging/` directory; existing canonical version intact. Next build cleans up. |
-| Cancel during prepared overlay build | Orphan `<overlay>-prepared/` directory; harmless. Next build falls through to live materialize. |
-| Overlay missing or corrupt | `materializeOverlay` rebuilds deterministically from canonical. Idempotent. |
+| Scenario                                    | Behaviour                                                                                                 |
+| ------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| Cancel during canonical publish             | Orphan `<sha>-staging/` directory; existing canonical version intact. Next build cleans up.               |
+| Cancel during prepared overlay build        | Orphan `<overlay>-prepared/` directory; harmless. Next build falls through to live materialize.           |
+| Overlay missing or corrupt                  | `materializeOverlay` rebuilds deterministically from canonical. Idempotent.                               |
 | Canonical missing (host loss, disk failure) | Next successful build re-establishes canonical via `publishCanonical`. One cold path back to clean state. |
-| Sentinel canary mismatch (when enabled) | Overlay is discarded; falls through to live materialize. |
+| Sentinel canary mismatch (when enabled)     | Overlay is discarded; falls through to live materialize.                                                  |
 
 ### Cross-platform behaviour
 
 The strategy degrades gracefully when filesystems don't support hardlinks. Build never fails
 because of strategy unavailability.
 
-| OS / Filesystem | Behaviour |
-|---|---|
-| Windows NTFS | Full implementation — hardlinks for files, directory junctions for read-only subtrees |
-| Windows ReFS | Hardlinks work; reflinks (per-file COW) documented as future stretch |
-| Linux ext4 / xfs | Hardlinks work; junctions emulated via symlinks or per-runner copy |
-| Linux btrfs / zfs | Hardlinks work; reflinks (block-level COW) documented as future stretch |
-| macOS APFS | Hardlinks work; clonefile reflinks documented as future stretch |
+| OS / Filesystem             | Behaviour                                                                                       |
+| --------------------------- | ----------------------------------------------------------------------------------------------- |
+| Windows NTFS                | Full implementation — hardlinks for files, directory junctions for read-only subtrees           |
+| Windows ReFS                | Hardlinks work; reflinks (per-file COW) documented as future stretch                            |
+| Linux ext4 / xfs            | Hardlinks work; junctions emulated via symlinks or per-runner copy                              |
+| Linux btrfs / zfs           | Hardlinks work; reflinks (block-level COW) documented as future stretch                         |
+| macOS APFS                  | Hardlinks work; clonefile reflinks documented as future stretch                                 |
 | Containerised runs (Docker) | Falls back to `move-directory` — canonical store doesn't make sense across container boundaries |
-| Cross-volume runners | Falls back to `move-directory` — hardlinks can't cross drive letters / mount points |
+| Cross-volume runners        | Falls back to `move-directory` — hardlinks can't cross drive letters / mount points             |
 
 When falling back, a structured warning is emitted via `OrchestratorLogger`.
 
@@ -463,15 +463,15 @@ When falling back, a structured warning is emitted via `OrchestratorLogger`.
 
 ### Performance characteristics
 
-| Configuration | Materialize time on critical path |
-|---|---|
-| `tar` | Minutes for multi-GB archive + extract |
-| `copy-directory` | Minutes for multi-GB byte copy |
-| `move-directory` | Sub-second, but consume-once across runners |
-| `canonical-overlay`, eager materialize | 15-30 s for ~200k files (hardlinks only) |
-| `canonical-overlay`, eager + PackageCache junctions | 2-8 s |
-| `canonical-overlay`, prepared overlay (steady state) | < 1 s (atomic rename) |
-| `canonical-overlay`, prepared overlay (canonical changed) | 2-8 s (live materialize fallback) |
+| Configuration                                             | Materialize time on critical path           |
+| --------------------------------------------------------- | ------------------------------------------- |
+| `tar`                                                     | Minutes for multi-GB archive + extract      |
+| `copy-directory`                                          | Minutes for multi-GB byte copy              |
+| `move-directory`                                          | Sub-second, but consume-once across runners |
+| `canonical-overlay`, eager materialize                    | 15-30 s for ~200k files (hardlinks only)    |
+| `canonical-overlay`, eager + PackageCache junctions       | 2-8 s                                       |
+| `canonical-overlay`, prepared overlay (steady state)      | < 1 s (atomic rename)                       |
+| `canonical-overlay`, prepared overlay (canonical changed) | 2-8 s (live materialize fallback)           |
 
 ### Future strategies in this taxonomy
 
@@ -542,20 +542,20 @@ caching strategies above — fewer wasted builds means less cache churn.
 
 ## Inputs Reference
 
-| Input                            | Description                                                                                                                  |
-| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `cacheKey`                       | Override the cache key used for cache isolation                                                                              |
-| `cacheCheckpointInterval`        | Minutes between Library checkpoints; `0` disables                                                                            |
-| `cacheSaveOnFailure`             | Save a partial cache after non-zero build exit                                                                               |
-| `cacheRetentionDays`             | Remove cache entries older than N days                                                                                       |
-| `maxRetainedWorkspaces`          | Number of retained full workspaces to keep                                                                                   |
-| `maxCacheEntries`                | Max tar snapshots to retain per cache folder (default: 2)                                                                    |
-| `minCacheEntries`                | Minimum cache entries to keep during age-based GC (floor)                                                                    |
-| `skipCache`                      | Skip cache restore entirely                                                                                                  |
-| `useCompressionStrategy`         | Use LZ4 compression for cache archives                                                                                       |
-| `localCacheMode`                 | One of `tar`, `move-directory`, `copy-directory`, `canonical-overlay`                                                        |
-| `canonicalCacheRoot`             | Path for the canonical store (when `localCacheMode: canonical-overlay`); falls back to `<localCacheRoot>/canonical`          |
-| `canonicalCacheClassifier`       | JSON describing per-subdirectory hardlink/junction/copy/skip strategy; defaults target Unity Library                         |
-| `canonicalCacheVersionRetention` | How many canonical SHA versions to keep per cache key (default: 2)                                                           |
-| `cacheMaterialize`               | `eager` (live materialize) or `prepared` (atomic-rename a pre-built overlay for sub-second hydration)                        |
-| `cacheSentinelCanary`            | Defense-in-depth corruption check; writes a known-content file into the overlay and verifies on consume                      |
+| Input                            | Description                                                                                                         |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `cacheKey`                       | Override the cache key used for cache isolation                                                                     |
+| `cacheCheckpointInterval`        | Minutes between Library checkpoints; `0` disables                                                                   |
+| `cacheSaveOnFailure`             | Save a partial cache after non-zero build exit                                                                      |
+| `cacheRetentionDays`             | Remove cache entries older than N days                                                                              |
+| `maxRetainedWorkspaces`          | Number of retained full workspaces to keep                                                                          |
+| `maxCacheEntries`                | Max tar snapshots to retain per cache folder (default: 2)                                                           |
+| `minCacheEntries`                | Minimum cache entries to keep during age-based GC (floor)                                                           |
+| `skipCache`                      | Skip cache restore entirely                                                                                         |
+| `useCompressionStrategy`         | Use LZ4 compression for cache archives                                                                              |
+| `localCacheMode`                 | One of `tar`, `move-directory`, `copy-directory`, `canonical-overlay`                                               |
+| `canonicalCacheRoot`             | Path for the canonical store (when `localCacheMode: canonical-overlay`); falls back to `<localCacheRoot>/canonical` |
+| `canonicalCacheClassifier`       | JSON describing per-subdirectory hardlink/junction/copy/skip strategy; defaults target Unity Library                |
+| `canonicalCacheVersionRetention` | How many canonical SHA versions to keep per cache key (default: 2)                                                  |
+| `cacheMaterialize`               | `eager` (live materialize) or `prepared` (atomic-rename a pre-built overlay for sub-second hydration)               |
+| `cacheSentinelCanary`            | Defense-in-depth corruption check; writes a known-content file into the overlay and verifies on consume             |

--- a/docs/03-github-orchestrator/07-advanced-topics/01-caching.mdx
+++ b/docs/03-github-orchestrator/07-advanced-topics/01-caching.mdx
@@ -301,16 +301,261 @@ preserve asset imports (textures, meshes, shader cache), which are profile-indep
 See [Self-Hosting and Orchestrator](self-hosting-and-orchestrator#profile-switching) for the
 fingerprinting pattern.
 
+## Canonical Cache + Overlay (Advanced)
+
+For studios running multiple self-hosted runners on the same physical host with multi-GB Library
+folders, the existing `localCacheMode` values trade off in known ways:
+
+- `tar` — pays archive + extract on every restore.
+- `move-directory` — instant atomic same-volume rename, but **consume-once**: only one runner
+  takes the cache; the next runner cold-starts.
+- `copy-directory` — multi-runner-safe, but pays full byte-copy cost on every restore. For a
+  30 GB Library folder this is minutes per build.
+
+The opt-in `canonical-overlay` mode combines the multi-runner safety of `copy-directory` with the
+zero-copy speed of `move-directory`. The pattern is well-known from VFSForGit, Scalar, the Nix
+store, and Bazel CAS: write the cache **once** to a content-addressed canonical store, and per-
+runner overlays consume it via OS-native hardlinks (NTFS on Windows, ext4/xfs/btrfs/zfs on Linux).
+
+### When to use it
+
+- Multiple self-hosted runners share the same physical host and filesystem.
+- Library folder is multi-GB; per-restore copy or extract is unacceptably slow.
+- Cancel-in-progress is foundational (CI cancels mid-flight pushes regularly), so the cache must
+  survive SIGKILL of the publishing job without corruption.
+
+### Architecture
+
+```
+<canonicalRoot>/<cacheKey>/
+    Library/
+        <sha-A>/             # canonical version A (hardlinked into runner overlays)
+        <sha-B>/             # canonical version B (current)
+        latest -> <sha-B>    # directory junction / symlink
+
+<runner workspace>/Library/
+    <files>                  # hardlinks pointing at canonical bytes
+```
+
+The canonical store is written **atomically** by `Publish-Canonical`:
+
+1. Walk the runner's freshly-built Library; hardlink files into `<sha-B>-staging/`.
+2. Write `.cache_complete` marker into the staging directory.
+3. Atomic rename `<sha-B>-staging/` → `<sha-B>/`. This is the publish moment.
+4. Atomic update of the `latest` pointer.
+
+If PostUnityJob is cancelled mid-publish (SIGKILL during the staging walk), the rename never
+happens. The orphan staging directory is harmless and gets cleaned up by the next build. The
+existing canonical version and `latest` pointer are intact.
+
+When PreUnityJob runs on any runner, `Materialize-Overlay` reads the `latest` pointer and creates
+hardlinks from canonical into a per-runner overlay directory. Hardlink creation is one syscall per
+file (~0.1 ms on Windows). For a Library with 200,000 files, materialization is ~20 s — orders of
+magnitude faster than copying multi-GB content.
+
+### Hardlink safety contract
+
+Not every Library subdirectory is safe to hardlink. The invariant: hardlink is safe only if the
+writer uses **write-temp-then-rename**, not in-place modification. In-place modification would
+write through the hardlink to canonical bytes, corrupting the canonical store for every consumer.
+
+The default classifier targets Unity's Library structure:
+
+| Subdirectory | Strategy | Why |
+|---|---|---|
+| `PackageCache/<package>@<hash>/` | Directory junction | Unity treats packages as immutable; new version = new `@<hash>` directory |
+| `ScriptAssemblies/`, `Artifacts/`, `BurstCache/`, `Bee/artifacts/`, `MetadataGenerator/`, `ShaderCache/`, `StateCache/`, `UIBuilder/`, `HDRPLibrary/` | Hardlink | Roslyn, Bee, AssetDatabase v2 all use write-temp-then-rename |
+| `PackageManager/projectResolution.json`, `PackageManager/ProjectCache`, `Bee/*.dag`, `Bee/*.dag.outputdata`, `Bee/*-inputdata.json`, `LastSceneManagerSetup.txt` | Per-runner copy | Contain absolute workspace paths; need cross-runner repair |
+| `AnnotationManager`, `EditorOnly`, `EditorUserBuildSettings.asset`, `EditorUserSettings.asset`, `CurrentLayout-*.dwlt` | Skip | Editor session state; not part of the build cache |
+| (default) | Hardlink | Conservative default for unknown subtrees |
+
+For non-Unity engines, override the classifier with `canonicalCacheClassifier`:
+
+```yaml
+- uses: game-ci/unity-builder@v4
+  with:
+    localCacheMode: canonical-overlay
+    canonicalCacheClassifier: |
+      {
+        "default": "hardlink",
+        "rules": [
+          { "pattern": "imported/**", "strategy": "junction" },
+          { "pattern": "session/**", "strategy": "skip" }
+        ]
+      }
+```
+
+### Configuration
+
+```yaml
+- uses: game-ci/unity-builder@v4
+  with:
+    localCacheEnabled: true
+    localCacheMode: canonical-overlay
+    canonicalCacheRoot: D:/CI/Canonical    # falls back to <localCacheRoot>/canonical
+    canonicalCacheVersionRetention: 2      # keep last 2 SHA versions per key
+    cacheMaterialize: prepared             # sub-second hydration
+    cacheSentinelCanary: true              # defense-in-depth
+```
+
+### Sub-second hydration with `prepared` materialize
+
+Eager materialize (the default for `canonical-overlay`) creates the overlay during PreUnityJob,
+on the build's critical path. For a 200k-file Library this is ~20 s.
+
+`cacheMaterialize: prepared` shifts the overlay creation off the critical path entirely. After a
+successful build:
+
+1. PostUnityJob publishes the canonical version.
+2. PostUnityJob then hardlink-clones the canonical into `<overlay>-prepared/`.
+3. The next PreUnityJob detects the prepared overlay, atomic-renames it into place, and starts
+   the build immediately.
+
+Sub-second hydration in the steady state. If the prepared overlay's SHA doesn't match the current
+canonical's `latest` SHA (a different runner published a newer version in between), it falls
+through to live materialize.
+
+### Failure modes and self-heal
+
+| Scenario | Behaviour |
+|---|---|
+| Cancel during canonical publish | Orphan `<sha>-staging/` directory; existing canonical version intact. Next build cleans up. |
+| Cancel during prepared overlay build | Orphan `<overlay>-prepared/` directory; harmless. Next build falls through to live materialize. |
+| Overlay missing or corrupt | `materializeOverlay` rebuilds deterministically from canonical. Idempotent. |
+| Canonical missing (host loss, disk failure) | Next successful build re-establishes canonical via `publishCanonical`. One cold path back to clean state. |
+| Sentinel canary mismatch (when enabled) | Overlay is discarded; falls through to live materialize. |
+
+### Cross-platform behaviour
+
+The strategy degrades gracefully when filesystems don't support hardlinks. Build never fails
+because of strategy unavailability.
+
+| OS / Filesystem | Behaviour |
+|---|---|
+| Windows NTFS | Full implementation — hardlinks for files, directory junctions for read-only subtrees |
+| Windows ReFS | Hardlinks work; reflinks (per-file COW) documented as future stretch |
+| Linux ext4 / xfs | Hardlinks work; junctions emulated via symlinks or per-runner copy |
+| Linux btrfs / zfs | Hardlinks work; reflinks (block-level COW) documented as future stretch |
+| macOS APFS | Hardlinks work; clonefile reflinks documented as future stretch |
+| Containerised runs (Docker) | Falls back to `move-directory` — canonical store doesn't make sense across container boundaries |
+| Cross-volume runners | Falls back to `move-directory` — hardlinks can't cross drive letters / mount points |
+
+When falling back, a structured warning is emitted via `OrchestratorLogger`.
+
+### Limitations
+
+1. **Single-host topology only.** All runners must share one filesystem. Multi-host CI farms need
+   different infrastructure (S3/MinIO via the existing `storageProvider` rclone path, or planned
+   future strategies — see "Future strategies" below).
+2. **NTFS, ext4, xfs needed for full benefit.** ReFS, btrfs, zfs, APFS work via hardlinks but
+   reflink-aware variants (per-file copy-on-write — strictly better) are documented as future
+   stretch options.
+3. **`Remove-Item -Recurse` on junctions has historically been unsafe in some PowerShell
+   versions.** The implementation uses `cmd /c rmdir /s /q` for junction-safe directory removal
+   on Windows.
+4. **1023 hardlinks per inode on NTFS.** Not a practical constraint at typical fleet sizes;
+   `canonicalCacheVersionRetention: 2` (default) limits inode-link count.
+5. **Modify-in-place writes propagate to canonical bytes.** Mitigated by the classifier audit
+   above. Unknown subtrees default to hardlink (conservative for read-mostly use); the
+   `cacheSentinelCanary` flag provides defense-in-depth.
+6. **Tested at scale on Windows NTFS in a 10-runner farm.** The Linux hardlink path lands with
+   platform-gated tests but has not been validated at multi-GB scale yet.
+
+### Performance characteristics
+
+| Configuration | Materialize time on critical path |
+|---|---|
+| `tar` | Minutes for multi-GB archive + extract |
+| `copy-directory` | Minutes for multi-GB byte copy |
+| `move-directory` | Sub-second, but consume-once across runners |
+| `canonical-overlay`, eager materialize | 15-30 s for ~200k files (hardlinks only) |
+| `canonical-overlay`, eager + PackageCache junctions | 2-8 s |
+| `canonical-overlay`, prepared overlay (steady state) | < 1 s (atomic rename) |
+| `canonical-overlay`, prepared overlay (canonical changed) | 2-8 s (live materialize fallback) |
+
+### Future strategies in this taxonomy
+
+The `localCacheMode` value space is extensible. Future strategies expected to follow the same
+shape (none implemented yet — RFC welcome):
+
+- **`reflink-overlay`** — block-level copy-on-write via Linux btrfs/xfs/zfs reflinks, macOS
+  APFS clonefile, or Windows ReFS. Equivalent to `canonical-overlay` but per-file COW (no
+  modify-in-place footgun).
+- **`bind-mount`** — read-only bind mount of canonical with overlayfs (Linux) or junction-based
+  Windows variants for filesystems that don't support fine-grained hardlinks.
+- **`nfs-passthrough`** — single-source-of-truth pattern; treat a network mount as canonical and
+  skip the publish step entirely. Trades network read latency for zero local disk usage.
+
+## Self-Hosted Operational Lessons
+
+The following operational lessons apply when running orchestrator on long-lived self-hosted
+runners. They surface symptoms that ephemeral runners never encounter.
+
+### PackageCache subtree corruption from cross-runner restore
+
+When `Library/PackageCache/<package>@<hash>/` is partially populated (an interrupted copy or
+extract), the directory may contain `.meta` files with no associated content files. Unity treats
+this as a hard error and aborts the import.
+
+Detect orphan-meta directories before Unity launches. Quarantine the affected package
+directories and let Unity re-extract them from the package's source on the next import.
+
+### PowerShell forward-reference bug masking real test failures
+
+In PowerShell scripts orchestrating Unity (a common pattern for `remote-powershell` provider
+jobs), calling a function before its definition silently fails in non-strict mode. The
+downstream error surfaces as the failure, hiding the real cause.
+
+Either set `Set-StrictMode -Version Latest` at the top of build scripts, or order helper
+function definitions before any code that calls them. This is especially important when scripts
+grow over time and developers add new top-level orchestration that calls helpers defined later
+in the same file.
+
+### GitHub Actions runner `_runner_file_commands` race
+
+When multiple steps in the same job emit `core.setOutput` concurrently (fan-out steps merging
+results back into the runner-level outputs file), they race on the shared
+`_runner_file_commands` runner-temp file. Symptom: outputs appear empty or corrupted, with no
+clear error.
+
+Serialise output-emitting steps. If a job needs to emit several outputs from parallel
+sub-jobs, collect them into a single output-emitting step at the end.
+
+### Path-filter on the workflow entrypoint to skip docs-only commits
+
+Docs-only pushes (markdown changes, README updates) shouldn't trigger Unity CI runs. A
+`paths-ignore` block on the workflow entrypoint prevents the orchestrator pipeline from
+spending build minutes on commits that can't change build output:
+
+```yaml
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - '*.txt'
+```
+
+This is a workflow-level concern, not an orchestrator setting, but it pairs naturally with the
+caching strategies above — fewer wasted builds means less cache churn.
+
 ## Inputs Reference
 
-| Input                     | Description                                               |
-| ------------------------- | --------------------------------------------------------- |
-| `cacheKey`                | Override the cache key used for cache isolation           |
-| `cacheCheckpointInterval` | Minutes between Library checkpoints; `0` disables         |
-| `cacheSaveOnFailure`      | Save a partial cache after non-zero build exit            |
-| `cacheRetentionDays`      | Remove cache entries older than N days                    |
-| `maxRetainedWorkspaces`   | Number of retained full workspaces to keep                |
-| `maxCacheEntries`         | Max tar snapshots to retain per cache folder (default: 2) |
-| `minCacheEntries`         | Minimum cache entries to keep during age-based GC (floor) |
-| `skipCache`               | Skip cache restore entirely                               |
-| `useCompressionStrategy`  | Use LZ4 compression for cache archives                    |
+| Input                            | Description                                                                                                                  |
+| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `cacheKey`                       | Override the cache key used for cache isolation                                                                              |
+| `cacheCheckpointInterval`        | Minutes between Library checkpoints; `0` disables                                                                            |
+| `cacheSaveOnFailure`             | Save a partial cache after non-zero build exit                                                                               |
+| `cacheRetentionDays`             | Remove cache entries older than N days                                                                                       |
+| `maxRetainedWorkspaces`          | Number of retained full workspaces to keep                                                                                   |
+| `maxCacheEntries`                | Max tar snapshots to retain per cache folder (default: 2)                                                                    |
+| `minCacheEntries`                | Minimum cache entries to keep during age-based GC (floor)                                                                    |
+| `skipCache`                      | Skip cache restore entirely                                                                                                  |
+| `useCompressionStrategy`         | Use LZ4 compression for cache archives                                                                                       |
+| `localCacheMode`                 | One of `tar`, `move-directory`, `copy-directory`, `canonical-overlay`                                                        |
+| `canonicalCacheRoot`             | Path for the canonical store (when `localCacheMode: canonical-overlay`); falls back to `<localCacheRoot>/canonical`          |
+| `canonicalCacheClassifier`       | JSON describing per-subdirectory hardlink/junction/copy/skip strategy; defaults target Unity Library                         |
+| `canonicalCacheVersionRetention` | How many canonical SHA versions to keep per cache key (default: 2)                                                           |
+| `cacheMaterialize`               | `eager` (live materialize) or `prepared` (atomic-rename a pre-built overlay for sub-second hydration)                        |
+| `cacheSentinelCanary`            | Defense-in-depth corruption check; writes a known-content file into the overlay and verifies on consume                      |

--- a/docs/03-github-orchestrator/07-advanced-topics/21-failures-and-diagnostics.mdx
+++ b/docs/03-github-orchestrator/07-advanced-topics/21-failures-and-diagnostics.mdx
@@ -294,7 +294,11 @@ When a failure lands in EXIT_NEG1 or GENERIC, manual investigation is required. 
 service cannot classify what it cannot match. Follow this sequence:
 
 1. **Pull the actual Unity Editor log** — CI wrapper output is a summary. The real failure details
-   are in `Editor.log` on the runner or in the provider's build container.
+   are in `Editor.log` on the runner or in the provider's build container. The
+   [Unity Log Collection](./22-unity-log-collection.mdx) feature pulls `Editor.log`,
+   `Unity.Licensing.Client.log`, `Unity.Entitlements.Audit.log`, `services-config.json`, the build
+   report, and `bee_backend.log` into a single artifact directory — set `collectUnityLogs: true`
+   on the failing run, re-run, and download the `unity-diagnostics` artifact.
 2. **Search for `error`, `Error`, `CRASH`, `Fatal`** — these keywords narrow the log to relevant
    sections.
 3. **Check the last 100 lines before exit** — Unity often logs the proximate cause immediately

--- a/docs/03-github-orchestrator/07-advanced-topics/22-unity-log-collection.mdx
+++ b/docs/03-github-orchestrator/07-advanced-topics/22-unity-log-collection.mdx
@@ -102,7 +102,7 @@ For finer control the underlying services are exported too — `UnityLogCollecto
 
 You don't have to wire `collectUnityLogs` into the build step ahead of time. The Orchestrator's
 **local provider** (`providerStrategy: local`) runs the same `UnityLogCollectorService` directly
-against the host, so you can SSH (or RDP) into a self-hosted runner *after* a failing job and pull
+against the host, so you can SSH (or RDP) into a self-hosted runner _after_ a failing job and pull
 every log Unity asks for in a single command — no workflow changes, no re-running the build.
 
 ```bash
@@ -146,26 +146,26 @@ The default categories cover everything Unity support has historically requested
 categories such as `license-file` are **excluded** unless you opt in with
 `unityLogsIncludeSensitive: true`.
 
-| Category              | Description                                            | Default   |
-| --------------------- | ------------------------------------------------------ | --------- |
-| `editor-log`          | `Editor.log` — primary build/import/compile log        | included  |
-| `editor-prev-log`     | `Editor-prev.log` — previous run, rotated on next launch | included  |
-| `licensing-client`    | `Unity.Licensing.Client.log`                           | included  |
-| `entitlements-audit`  | `Unity.Entitlements.Audit.log`                         | included  |
-| `services-config`     | `services-config.json` (license server / Hub config)   | included  |
-| `unity-hub-info`      | Unity Hub `info-log.json`                              | included  |
-| `unity-hub-error`     | Unity Hub `error-log.json`                             | included  |
-| `editor-crash`        | Editor crash dump directory                            | included  |
-| `build-report`        | `Library/LastBuild.buildreport` (binary; opens in Unity Build Profiler) | included |
-| `bee-backend`         | `Library/Bee/bee_backend.log` (incremental build pipeline) | included  |
-| `player-log`          | `Player.log` for the built player (when present)       | included  |
-| `test-results`        | Unity test runner XML (`TestResults/` and `test-results/`) | included |
-| `il2cpp-output`       | `Temp/StagingArea/Data/il2cppOutput/` (generated C++)  | included  |
-| `project-version`     | `ProjectSettings/ProjectVersion.txt`                   | included  |
-| `package-manifest`    | `Packages/manifest.json` and `packages-lock.json`      | included  |
-| `macos-crash-report`  | `~/Library/Logs/DiagnosticReports/Unity-*.crash`       | included  |
-| `windows-event-log`   | `Get-WinEvent -ProviderName 'Unity'` slice (200 lines) | included  |
-| `license-file`        | `Unity_lic.ulf` — **SENSITIVE**, only with `unityLogsIncludeSensitive` | excluded |
+| Category             | Description                                                             | Default  |
+| -------------------- | ----------------------------------------------------------------------- | -------- |
+| `editor-log`         | `Editor.log` — primary build/import/compile log                         | included |
+| `editor-prev-log`    | `Editor-prev.log` — previous run, rotated on next launch                | included |
+| `licensing-client`   | `Unity.Licensing.Client.log`                                            | included |
+| `entitlements-audit` | `Unity.Entitlements.Audit.log`                                          | included |
+| `services-config`    | `services-config.json` (license server / Hub config)                    | included |
+| `unity-hub-info`     | Unity Hub `info-log.json`                                               | included |
+| `unity-hub-error`    | Unity Hub `error-log.json`                                              | included |
+| `editor-crash`       | Editor crash dump directory                                             | included |
+| `build-report`       | `Library/LastBuild.buildreport` (binary; opens in Unity Build Profiler) | included |
+| `bee-backend`        | `Library/Bee/bee_backend.log` (incremental build pipeline)              | included |
+| `player-log`         | `Player.log` for the built player (when present)                        | included |
+| `test-results`       | Unity test runner XML (`TestResults/` and `test-results/`)              | included |
+| `il2cpp-output`      | `Temp/StagingArea/Data/il2cppOutput/` (generated C++)                   | included |
+| `project-version`    | `ProjectSettings/ProjectVersion.txt`                                    | included |
+| `package-manifest`   | `Packages/manifest.json` and `packages-lock.json`                       | included |
+| `macos-crash-report` | `~/Library/Logs/DiagnosticReports/Unity-*.crash`                        | included |
+| `windows-event-log`  | `Get-WinEvent -ProviderName 'Unity'` slice (200 lines)                  | included |
+| `license-file`       | `Unity_lic.ulf` — **SENSITIVE**, only with `unityLogsIncludeSensitive`  | excluded |
 
 To collect a subset only, pass a comma-separated list to `unityLogCategories`:
 
@@ -180,20 +180,20 @@ with:
 The collector resolves paths per-platform and per-runner. The same flag works on Linux, macOS, and
 Windows runners with no further configuration.
 
-| Category             | Linux                                              | macOS                                                       | Windows                                       |
-| -------------------- | -------------------------------------------------- | ----------------------------------------------------------- | --------------------------------------------- |
-| `editor-log`         | `~/.config/unity3d/Editor.log`                     | `~/Library/Logs/Unity/Editor.log`                            | `%LOCALAPPDATA%\Unity\Editor\Editor.log`      |
-| `licensing-client`   | `~/.config/unity3d/Unity/Unity.Licensing.Client.log` | `~/Library/Logs/Unity/Unity.Licensing.Client.log`          | `%LOCALAPPDATA%\Unity\Unity.Licensing.Client.log` |
-| `entitlements-audit` | `~/.config/unity3d/Unity/Unity.Entitlements.Audit.log` | `~/Library/Logs/Unity/Unity.Entitlements.Audit.log`     | `%LOCALAPPDATA%\Unity\Unity.Entitlements.Audit.log` |
-| `services-config`    | `/usr/share/unity3d/config/services-config.json`   | `/Library/Application Support/Unity/config/services-config.json` | `%PROGRAMDATA%\Unity\config\services-config.json` |
-| `unity-hub-*`        | `~/.config/UnityHub/logs/*.json`                   | `~/Library/Application Support/UnityHub/logs/*.json`        | `%APPDATA%\UnityHub\logs\*.json`              |
-| `editor-crash`       | `~/.config/unity3d/Crashes`                        | `~/Library/Logs/Unity/Crashes`                              | `%LOCALAPPDATA%\Unity\Editor\Crash`           |
-| `build-report`       | `<project>/Library/LastBuild.buildreport`          | _same_                                                      | _same_                                         |
-| `bee-backend`        | `<project>/Library/Bee/bee_backend.log`            | _same_                                                      | _same_                                         |
-| `project-version`    | `<project>/ProjectSettings/ProjectVersion.txt`     | _same_                                                      | _same_                                         |
-| `package-manifest`   | `<project>/Packages/manifest.json`                 | _same_                                                      | _same_                                         |
-| `windows-event-log`  | _n/a_                                              | _n/a_                                                       | `Get-WinEvent -ProviderName 'Unity'`          |
-| `macos-crash-report` | _n/a_                                              | `~/Library/Logs/DiagnosticReports/Unity-*.crash`            | _n/a_                                          |
+| Category             | Linux                                                  | macOS                                                            | Windows                                             |
+| -------------------- | ------------------------------------------------------ | ---------------------------------------------------------------- | --------------------------------------------------- |
+| `editor-log`         | `~/.config/unity3d/Editor.log`                         | `~/Library/Logs/Unity/Editor.log`                                | `%LOCALAPPDATA%\Unity\Editor\Editor.log`            |
+| `licensing-client`   | `~/.config/unity3d/Unity/Unity.Licensing.Client.log`   | `~/Library/Logs/Unity/Unity.Licensing.Client.log`                | `%LOCALAPPDATA%\Unity\Unity.Licensing.Client.log`   |
+| `entitlements-audit` | `~/.config/unity3d/Unity/Unity.Entitlements.Audit.log` | `~/Library/Logs/Unity/Unity.Entitlements.Audit.log`              | `%LOCALAPPDATA%\Unity\Unity.Entitlements.Audit.log` |
+| `services-config`    | `/usr/share/unity3d/config/services-config.json`       | `/Library/Application Support/Unity/config/services-config.json` | `%PROGRAMDATA%\Unity\config\services-config.json`   |
+| `unity-hub-*`        | `~/.config/UnityHub/logs/*.json`                       | `~/Library/Application Support/UnityHub/logs/*.json`             | `%APPDATA%\UnityHub\logs\*.json`                    |
+| `editor-crash`       | `~/.config/unity3d/Crashes`                            | `~/Library/Logs/Unity/Crashes`                                   | `%LOCALAPPDATA%\Unity\Editor\Crash`                 |
+| `build-report`       | `<project>/Library/LastBuild.buildreport`              | _same_                                                           | _same_                                              |
+| `bee-backend`        | `<project>/Library/Bee/bee_backend.log`                | _same_                                                           | _same_                                              |
+| `project-version`    | `<project>/ProjectSettings/ProjectVersion.txt`         | _same_                                                           | _same_                                              |
+| `package-manifest`   | `<project>/Packages/manifest.json`                     | _same_                                                           | _same_                                              |
+| `windows-event-log`  | _n/a_                                                  | _n/a_                                                            | `Get-WinEvent -ProviderName 'Unity'`                |
+| `macos-crash-report` | _n/a_                                                  | `~/Library/Logs/DiagnosticReports/Unity-*.crash`                 | _n/a_                                               |
 
 For Linux **container** builds, the workspace-relative paths (`build-report`, `bee-backend`,
 `project-version`, `package-manifest`, `test-results`, `il2cpp-output`) are always available
@@ -230,24 +230,24 @@ These inputs are accepted by `game-ci/unity-builder` (which forwards to the Orch
 and by `game-ci/unity-orchestrator` directly. They also work as `--collectUnityLogs` etc. flags on
 the standalone `game-ci` CLI.
 
-| Input                       | Default | Description                                                   |
-| --------------------------- | ------- | ------------------------------------------------------------- |
-| `collectUnityLogs`          | `false` | Enable post-build collection.                                 |
-| `collectUnityLogsOnSuccess` | `true`  | When false, only collect on non-zero exit codes.              |
-| `unityLogCategories`        | _all_   | Comma-separated subset of categories.                         |
-| `unityLogsIncludeSensitive` | `false` | Include sensitive categories such as `license-file`.          |
-| `unityLogsOutputDir`        | _auto_  | Override the artifact directory.                              |
-| `streamUnityLogs`           | `false` | Live-tail Unity log files during the build.                   |
-| `streamUnityLogPaths`       | _auto_  | Comma-separated files to live-tail (overrides defaults).      |
+| Input                       | Default | Description                                              |
+| --------------------------- | ------- | -------------------------------------------------------- |
+| `collectUnityLogs`          | `false` | Enable post-build collection.                            |
+| `collectUnityLogsOnSuccess` | `true`  | When false, only collect on non-zero exit codes.         |
+| `unityLogCategories`        | _all_   | Comma-separated subset of categories.                    |
+| `unityLogsIncludeSensitive` | `false` | Include sensitive categories such as `license-file`.     |
+| `unityLogsOutputDir`        | _auto_  | Override the artifact directory.                         |
+| `streamUnityLogs`           | `false` | Live-tail Unity log files during the build.              |
+| `streamUnityLogPaths`       | _auto_  | Comma-separated files to live-tail (overrides defaults). |
 
 ## Outputs
 
 After the build, the Orchestrator emits two GitHub Actions outputs:
 
-| Output                | Description                                                        |
-| --------------------- | ------------------------------------------------------------------ |
-| `unityLogsPath`       | Absolute path to the collected directory.                          |
-| `unityLogsManifest`   | Path to the manifest JSON describing every collected/missing item. |
+| Output              | Description                                                        |
+| ------------------- | ------------------------------------------------------------------ |
+| `unityLogsPath`     | Absolute path to the collected directory.                          |
+| `unityLogsManifest` | Path to the manifest JSON describing every collected/missing item. |
 
 ```yaml
 - id: build
@@ -279,9 +279,7 @@ A typical `manifest.json`:
       "isDirectory": false
     }
   ],
-  "missing": [
-    { "category": "macos-crash-report", "expectedPaths": [] }
-  ],
+  "missing": [{ "category": "macos-crash-report", "expectedPaths": [] }],
   "totalBytes": 2148102
 }
 ```

--- a/docs/03-github-orchestrator/07-advanced-topics/22-unity-log-collection.mdx
+++ b/docs/03-github-orchestrator/07-advanced-topics/22-unity-log-collection.mdx
@@ -45,6 +45,59 @@ Result: a `unity-diagnostics` artifact containing one folder per category, plus 
 summarising what was found, what was missing, and where each file came from. Attach the artifact
 to your Unity support ticket.
 
+## Convenient API
+
+Two surfaces are available — pick whichever matches how you're driving the build.
+
+### `game-ci logs` CLI
+
+```bash
+# Run the collector against the local host (no orchestrate ceremony)
+game-ci logs collect --unityLogsOutputDir ./unity-bundle
+
+# Pick a subset of categories
+game-ci logs collect \
+  --unityLogCategories editor-log,licensing-client,entitlements-audit,services-config \
+  --unityLogsOutputDir ./unity-bundle
+
+# Live-tail Editor.log (Ctrl+C to stop)
+game-ci logs tail
+game-ci logs tail --streamUnityLogPaths /path/to/Editor.log,/path/to/Player.log
+
+# Reserved for the upcoming remote-provider exec / retroactive fetch
+game-ci logs pull   # not yet implemented — see roadmap
+game-ci logs fetch  # not yet implemented — see roadmap
+```
+
+The same `--collectUnityLogs` / `--streamUnityLogs` flags continue to work on `game-ci build` and
+`game-ci orchestrate` for end-to-end use during a build.
+
+### `Logs` programmatic API (Node / TypeScript)
+
+```ts
+import { Logs } from '@game-ci/orchestrator';
+
+// Collect everything Unity support typically asks for
+const result = await Logs.collect({
+  outputDir: './unity-support-bundle',
+});
+console.log(`${result.collected.length} item(s), manifest at ${result.manifestPath}`);
+
+// Live-tail Editor.log
+const tail = Logs.tail({ files: ['/github/workspace/Builds/Logs/Editor.log'] });
+// ...later
+tail.stop();
+
+// Introspect available categories (e.g. to populate a UI)
+for (const definition of Logs.categories()) {
+  console.log(definition.category, definition.description, definition.sensitive ?? false);
+}
+```
+
+For finer control the underlying services are exported too — `UnityLogCollectorService`,
+`UnityLogTailService`, and the `UNITY_LOG_PATHS` registry are all reachable from
+`@game-ci/orchestrator`.
+
 ## Pulling Logs Ad-Hoc Via the Local Provider
 
 You don't have to wire `collectUnityLogs` into the build step ahead of time. The Orchestrator's

--- a/docs/03-github-orchestrator/07-advanced-topics/22-unity-log-collection.mdx
+++ b/docs/03-github-orchestrator/07-advanced-topics/22-unity-log-collection.mdx
@@ -45,6 +45,48 @@ Result: a `unity-diagnostics` artifact containing one folder per category, plus 
 summarising what was found, what was missing, and where each file came from. Attach the artifact
 to your Unity support ticket.
 
+## Pulling Logs Ad-Hoc Via the Local Provider
+
+You don't have to wire `collectUnityLogs` into the build step ahead of time. The Orchestrator's
+**local provider** (`providerStrategy: local`) runs the same `UnityLogCollectorService` directly
+against the host, so you can SSH (or RDP) into a self-hosted runner *after* a failing job and pull
+every log Unity asks for in a single command — no workflow changes, no re-running the build.
+
+```bash
+# on the self-hosted runner, after the failing job
+game-ci orchestrate \
+  --providerStrategy local \
+  --collectUnityLogs \
+  --unityLogsOutputDir ./unity-support-bundle
+
+# → ./unity-support-bundle/manifest.json
+# → ./unity-support-bundle/editor-log/Editor.log
+# → ./unity-support-bundle/licensing-client/Unity.Licensing.Client.log
+# → ./unity-support-bundle/entitlements-audit/Unity.Entitlements.Audit.log
+# → ./unity-support-bundle/services-config/services-config.json
+# → ...
+```
+
+The collector reads from the canonical Unity paths
+(`%LOCALAPPDATA%\Unity\…`, `~/.config/unity3d/…`, `~/Library/Logs/Unity/…`,
+`/usr/share/unity3d/config/…`), so as long as the runner still has the files Unity wrote during
+the failing build, you can grab them retroactively without re-running anything. Useful when:
+
+- A CI run failed overnight and you want a Unity-support-ready bundle before the next build
+  rotates `Editor.log` to `Editor-prev.log`.
+- You need the licensing/audit logs from a specific runner but cannot edit the workflow file
+  (e.g. central platform team owns it).
+- You're debugging a hang and need to copy the in-progress `Editor.log` plus crash dump dir from
+  the live runner.
+
+The same `--unityLogCategories`, `--unityLogsIncludeSensitive`, and `--streamUnityLogs` flags work
+in this mode — the local provider is just a thin wrapper around the collector service.
+
+For runners you don't have shell access to, the upcoming `game-ci logs pull --providerStrategy
+<aws|k8s>` command will execute the collector inside the active pod / VM via the provider
+interface and stream the bundle back; until then, this local-provider recipe is the
+no-prior-opt-in escape hatch.
+
 ## What Gets Collected
 
 The default categories cover everything Unity support has historically requested. Sensitive

--- a/docs/03-github-orchestrator/07-advanced-topics/22-unity-log-collection.mdx
+++ b/docs/03-github-orchestrator/07-advanced-topics/22-unity-log-collection.mdx
@@ -1,0 +1,225 @@
+---
+sidebar_position: 22
+toc_max_heading_level: 4
+---
+
+# Unity Log Collection
+
+Unity support frequently asks for files that live **outside** the project workspace — `Editor.log`,
+`Unity.Licensing.Client.log`, `Unity.Entitlements.Audit.log`, `services-config.json`, Unity Hub
+logs, crash dumps, build reports, the Bee build pipeline log, IL2CPP output, and more. On a CI
+runner none of those land in the workspace by default, so they never make it into the artifact
+upload, and there is no convenient way to send them to Unity when a ticket is opened.
+
+The Orchestrator includes a built-in collector that gathers all of those files into a single
+`Logs/UnityDiagnostics/` directory at the end of every build. The same flag also turns the
+directory into an artifact so it shows up alongside the build output. A separate flag streams
+`Editor.log` live to the GitHub Actions log while the build runs.
+
+These features are **opt-in** and engine-aware: the Unity collector is the built-in, but the same
+plugin model that drives Godot and Unreal cache folders can register additional engine-specific
+diagnostic paths in the future.
+
+## Quick Start
+
+Add `collectUnityLogs: true` to your existing `unity-builder` (or `unity-orchestrator`) step.
+Everything else is automatic:
+
+```yaml
+- name: Build with Unity
+  uses: game-ci/unity-builder@v4
+  with:
+    targetPlatform: StandaloneLinux64
+    collectUnityLogs: true
+    streamUnityLogs: true # optional — live tail Editor.log to GHA log
+
+- name: Upload Unity diagnostic logs
+  if: always()
+  uses: actions/upload-artifact@v4
+  with:
+    name: unity-diagnostics
+    path: ${{ github.workspace }}/Logs/UnityDiagnostics/
+```
+
+Result: a `unity-diagnostics` artifact containing one folder per category, plus a `manifest.json`
+summarising what was found, what was missing, and where each file came from. Attach the artifact
+to your Unity support ticket.
+
+## What Gets Collected
+
+The default categories cover everything Unity support has historically requested. Sensitive
+categories such as `license-file` are **excluded** unless you opt in with
+`unityLogsIncludeSensitive: true`.
+
+| Category              | Description                                            | Default   |
+| --------------------- | ------------------------------------------------------ | --------- |
+| `editor-log`          | `Editor.log` — primary build/import/compile log        | included  |
+| `editor-prev-log`     | `Editor-prev.log` — previous run, rotated on next launch | included  |
+| `licensing-client`    | `Unity.Licensing.Client.log`                           | included  |
+| `entitlements-audit`  | `Unity.Entitlements.Audit.log`                         | included  |
+| `services-config`     | `services-config.json` (license server / Hub config)   | included  |
+| `unity-hub-info`      | Unity Hub `info-log.json`                              | included  |
+| `unity-hub-error`     | Unity Hub `error-log.json`                             | included  |
+| `editor-crash`        | Editor crash dump directory                            | included  |
+| `build-report`        | `Library/LastBuild.buildreport` (binary; opens in Unity Build Profiler) | included |
+| `bee-backend`         | `Library/Bee/bee_backend.log` (incremental build pipeline) | included  |
+| `player-log`          | `Player.log` for the built player (when present)       | included  |
+| `test-results`        | Unity test runner XML (`TestResults/` and `test-results/`) | included |
+| `il2cpp-output`       | `Temp/StagingArea/Data/il2cppOutput/` (generated C++)  | included  |
+| `project-version`     | `ProjectSettings/ProjectVersion.txt`                   | included  |
+| `package-manifest`    | `Packages/manifest.json` and `packages-lock.json`      | included  |
+| `macos-crash-report`  | `~/Library/Logs/DiagnosticReports/Unity-*.crash`       | included  |
+| `windows-event-log`   | `Get-WinEvent -ProviderName 'Unity'` slice (200 lines) | included  |
+| `license-file`        | `Unity_lic.ulf` — **SENSITIVE**, only with `unityLogsIncludeSensitive` | excluded |
+
+To collect a subset only, pass a comma-separated list to `unityLogCategories`:
+
+```yaml
+with:
+  collectUnityLogs: true
+  unityLogCategories: editor-log,licensing-client,entitlements-audit,services-config
+```
+
+## Path Resolution
+
+The collector resolves paths per-platform and per-runner. The same flag works on Linux, macOS, and
+Windows runners with no further configuration.
+
+| Category             | Linux                                              | macOS                                                       | Windows                                       |
+| -------------------- | -------------------------------------------------- | ----------------------------------------------------------- | --------------------------------------------- |
+| `editor-log`         | `~/.config/unity3d/Editor.log`                     | `~/Library/Logs/Unity/Editor.log`                            | `%LOCALAPPDATA%\Unity\Editor\Editor.log`      |
+| `licensing-client`   | `~/.config/unity3d/Unity/Unity.Licensing.Client.log` | `~/Library/Logs/Unity/Unity.Licensing.Client.log`          | `%LOCALAPPDATA%\Unity\Unity.Licensing.Client.log` |
+| `entitlements-audit` | `~/.config/unity3d/Unity/Unity.Entitlements.Audit.log` | `~/Library/Logs/Unity/Unity.Entitlements.Audit.log`     | `%LOCALAPPDATA%\Unity\Unity.Entitlements.Audit.log` |
+| `services-config`    | `/usr/share/unity3d/config/services-config.json`   | `/Library/Application Support/Unity/config/services-config.json` | `%PROGRAMDATA%\Unity\config\services-config.json` |
+| `unity-hub-*`        | `~/.config/UnityHub/logs/*.json`                   | `~/Library/Application Support/UnityHub/logs/*.json`        | `%APPDATA%\UnityHub\logs\*.json`              |
+| `editor-crash`       | `~/.config/unity3d/Crashes`                        | `~/Library/Logs/Unity/Crashes`                              | `%LOCALAPPDATA%\Unity\Editor\Crash`           |
+| `build-report`       | `<project>/Library/LastBuild.buildreport`          | _same_                                                      | _same_                                         |
+| `bee-backend`        | `<project>/Library/Bee/bee_backend.log`            | _same_                                                      | _same_                                         |
+| `project-version`    | `<project>/ProjectSettings/ProjectVersion.txt`     | _same_                                                      | _same_                                         |
+| `package-manifest`   | `<project>/Packages/manifest.json`                 | _same_                                                      | _same_                                         |
+| `windows-event-log`  | _n/a_                                              | _n/a_                                                       | `Get-WinEvent -ProviderName 'Unity'`          |
+| `macos-crash-report` | _n/a_                                              | `~/Library/Logs/DiagnosticReports/Unity-*.crash`            | _n/a_                                          |
+
+For Linux **container** builds, the workspace-relative paths (`build-report`, `bee-backend`,
+`project-version`, `package-manifest`, `test-results`, `il2cpp-output`) are always available
+because they live inside the mounted project directory. For the host-side categories that live
+under `/root/.config/unity3d/` inside the container, the container exit script copies them to
+`<workspace>/Logs/UnityDiagnostics/<category>/` before the container exits, so they are available
+on the host for the artifact upload step.
+
+## Live Log Streaming
+
+`streamUnityLogs: true` tails Unity's `-logFile` output during the build and forwards each new
+line to the GHA log. This is useful for long builds where you want to watch compile progress
+without waiting for the build to finish, and for debugging hangs where the build never produces a
+final log dump.
+
+```yaml
+with:
+  collectUnityLogs: true
+  streamUnityLogs: true
+  streamUnityLogPaths: '' # optional comma-separated override
+```
+
+By default the orchestrator tails:
+
+- `<project>/Builds/Logs/Editor.log` — what `unity-builder` configures via `-logFile`
+- `<project>/Logs/UnityDiagnostics/editor-log/Editor.log` — once the post-build copy lands
+
+A 5 MB per-file cap prevents runaway log spam in pathological cases. Each emitted line is prefixed
+with `[UnityLogs] Editor.log:` so the streamed lines stay greppable in a busy GHA log.
+
+## Inputs
+
+These inputs are accepted by `game-ci/unity-builder` (which forwards to the Orchestrator plugin)
+and by `game-ci/unity-orchestrator` directly. They also work as `--collectUnityLogs` etc. flags on
+the standalone `game-ci` CLI.
+
+| Input                       | Default | Description                                                   |
+| --------------------------- | ------- | ------------------------------------------------------------- |
+| `collectUnityLogs`          | `false` | Enable post-build collection.                                 |
+| `collectUnityLogsOnSuccess` | `true`  | When false, only collect on non-zero exit codes.              |
+| `unityLogCategories`        | _all_   | Comma-separated subset of categories.                         |
+| `unityLogsIncludeSensitive` | `false` | Include sensitive categories such as `license-file`.          |
+| `unityLogsOutputDir`        | _auto_  | Override the artifact directory.                              |
+| `streamUnityLogs`           | `false` | Live-tail Unity log files during the build.                   |
+| `streamUnityLogPaths`       | _auto_  | Comma-separated files to live-tail (overrides defaults).      |
+
+## Outputs
+
+After the build, the Orchestrator emits two GitHub Actions outputs:
+
+| Output                | Description                                                        |
+| --------------------- | ------------------------------------------------------------------ |
+| `unityLogsPath`       | Absolute path to the collected directory.                          |
+| `unityLogsManifest`   | Path to the manifest JSON describing every collected/missing item. |
+
+```yaml
+- id: build
+  uses: game-ci/unity-builder@v4
+  with:
+    targetPlatform: StandaloneLinux64
+    collectUnityLogs: true
+
+- name: Print log path
+  run: echo "Logs at ${{ steps.build.outputs.unityLogsPath }}"
+```
+
+A typical `manifest.json`:
+
+```json
+{
+  "generatedAt": "2026-05-07T18:42:13.014Z",
+  "platform": "linux",
+  "workspace": "/github/workspace",
+  "projectPath": "/github/workspace/MyProject",
+  "includeSensitive": false,
+  "collected": [
+    {
+      "category": "editor-log",
+      "description": "Unity Editor.log — primary build/import/compile log",
+      "source": "/github/workspace/Logs/UnityDiagnostics/editor-log/Editor.log",
+      "destination": "editor-log/Editor.log",
+      "bytes": 1843291,
+      "isDirectory": false
+    }
+  ],
+  "missing": [
+    { "category": "macos-crash-report", "expectedPaths": [] }
+  ],
+  "totalBytes": 2148102
+}
+```
+
+## Sending Logs to Unity Support
+
+1. Enable `collectUnityLogs: true` (and optionally `streamUnityLogs: true`) on the failing run.
+2. Re-run the workflow.
+3. Download the `unity-diagnostics` artifact from the run summary page.
+4. Attach the **whole zip** to the Unity ticket. The `manifest.json` tells the support engineer
+   which files were captured and which categories were unavailable on that runner.
+
+## Sensitive Files
+
+The default list explicitly excludes the `Unity_lic.ulf` license file and any other category
+marked `sensitive`. License files contain the activation token for your seat — uploading them to a
+public CI artifact is equivalent to publishing your license. The collector logs a warning and
+skips the category unless you set `unityLogsIncludeSensitive: true`.
+
+If you must collect a license file (for a private support escalation), set the flag, run the
+workflow, **download the artifact, delete it from GitHub immediately**, then disable the flag
+again. Treat the artifact like a credential.
+
+## Multi-Engine Note
+
+Engine plugins for Godot, Unreal, and custom engines plug into the same lifecycle. Today only the
+Unity collector ships in-tree; the path registry is engine-scoped, so a future Unreal plugin can
+register `Saved/Logs/<project>.log`, `Intermediate/BuildRules/`, and similar in the same way. The
+flags (`collectUnityLogs`, `streamUnityLogs`) keep their Unity-prefixed names for backwards
+compatibility — engine-agnostic equivalents will be added when a second engine collector lands.
+
+## See Also
+
+- [Failures and Diagnostics](./21-failures-and-diagnostics.mdx) — the wider failure-handling model
+- [Build Reliability](./17-build-reliability.mdx) — retry, recovery, and crash classification
+- [Engine Plugins](./18-engine-plugins.mdx) — how non-Unity engines plug in

--- a/docs/08-docker/01-docker-images.mdx
+++ b/docs/08-docker/01-docker-images.mdx
@@ -14,6 +14,10 @@ Images for newly released Unity editor versions are added almost immediately to
 [`game-ci/docker`](https://github.com/game-ci/docker/) . This process is automated, please allow a
 few hours.
 
+If you need a Unity editor image with multiple build modules installed together, use the
+[`game-ci build-unity-image` CLI command](/docs/docker/custom-images). It generates images from the
+same Docker build logic that GameCI uses for the published `unityci/editor` images.
+
 ## Features
 
 - All editor versions

--- a/docs/08-docker/03-customize-docker-images.mdx
+++ b/docs/08-docker/03-customize-docker-images.mdx
@@ -6,6 +6,11 @@ with blender assets. Sometimes, you'll need some specific command lines or runti
 unity in a _postprocess_ step. This documentation will guide you into building your own images on
 top of the existing ones to add your desired tools.
 
+If you only need multiple Unity modules in one editor image, prefer
+[`game-ci build-unity-image`](/docs/docker/custom-images) instead of maintaining a custom
+Dockerfile. Keep this guide for extra operating-system tools or project-specific dependencies that
+are not part of Unity's module installer.
+
 ## Example: Add Ruby to existing images
 
 In the following example, we will be adding `Ruby` on top of the existing docker images (all unity

--- a/docs/08-docker/05-custom-images.mdx
+++ b/docs/08-docker/05-custom-images.mdx
@@ -72,9 +72,11 @@ Hub and base image defaults unless you override them with `--hub-image` and `--b
 
 ## GitHub Actions Example
 
-### On-the-fly (with caching)
+### Build-and-use locally (no registry needed)
 
-Build the image as a CI step. Docker layer caching makes subsequent runs fast:
+Most projects don't need to publish their Unity editor image — build it as a CI step, tag
+it locally, and reference that local tag in the same job. The image lives only in the
+runner's Docker daemon for the lifetime of the job:
 
 ```yaml
 jobs:
@@ -98,9 +100,30 @@ jobs:
           targetPlatform: StandaloneWindows64
 ```
 
+No GHCR account, no `docker login`, no pushed bytes. The image never leaves the runner.
+
+#### Build cost and caching
+
+The CLI invokes `docker build` directly. Image build time is dominated by Unity Hub
+installing the editor and modules — expect 15-30 minutes for typical desktop combos. On
+GitHub-hosted runners that work is repeated every job because the runner (and its Docker
+daemon) is destroyed at the end of each run.
+
+If that rebuild cost is acceptable for your cadence, you're done. Otherwise pick one of:
+
+| Strategy                       | What you set up                                                                | Best for                                         |
+| ------------------------------ | ------------------------------------------------------------------------------ | ------------------------------------------------ |
+| **Self-hosted runner**         | A persistent runner whose Docker daemon retains layers between jobs            | Teams already running self-hosted infrastructure |
+| **Push once, pull thereafter** | Build the image in a scheduled workflow, push to GHCR, pull in build workflows | Stable module combos used by many runs           |
+| **Buildx + GHA cache backend** | Wrap the build with `docker/setup-buildx-action` and a cache-aware build step  | Frequent module/version churn on hosted runners  |
+
+The push-once strategy is covered below. For self-hosted runner caching, see the
+[orchestrator caching guide](/docs/github-orchestrator/advanced-topics/caching).
+
 ### Pre-built (push once, pull forever)
 
-Build and push the image to a registry once, then reference it in all builds:
+When the same image is used across many workflows, repos, or runs, push it to a registry
+once and reference it everywhere:
 
 ```yaml
 # Run once (or on a schedule)

--- a/docs/08-docker/05-custom-images.mdx
+++ b/docs/08-docker/05-custom-images.mdx
@@ -25,6 +25,10 @@ game-ci build-unity-image ubuntu windows-mono,linux-il2cpp \
   --unity-version 2022.3.20f1 \
   --tag ghcr.io/my-org/unity-editor:desktop \
   --push
+
+# Build a Windows-based editor image
+game-ci build-unity-image windows windows-mono,mac-mono \
+  --unity-version 2022.3.20f1
 ```
 
 ## Usage
@@ -50,6 +54,9 @@ game-ci build-unity-image [baseOs] [modules] [options]
 | `--push`          | `false`            | Push image to registry after building     |
 | `--hub-image`     | `unityci/hub`      | Hub base image                            |
 | `--base-image`    | `unityci/base`     | Editor base image                         |
+
+The CLI also supports `baseOs=windows`. When you select `windows`, the command uses the Windows
+Hub and base image defaults unless you override them with `--hub-image` and `--base-image`.
 
 ### Available Modules
 
@@ -133,6 +140,7 @@ Then in your build workflow:
 | Name              | Modules                              | Use case                         |
 | ----------------- | ------------------------------------ | -------------------------------- |
 | Desktop           | `windows-mono,linux-il2cpp,mac-mono` | Wwise/FMOD, Steam multi-platform |
+| Windows desktop   | `windows-mono,mac-mono`              | Windows-hosted plugin workflows  |
 | Desktop + Android | `windows-mono,linux-il2cpp,android`  | Meta Quest + PC VR               |
 | Mobile            | `android,ios`                        | Multi-platform mobile            |
 

--- a/docs/09-troubleshooting/common-issues.mdx
+++ b/docs/09-troubleshooting/common-issues.mdx
@@ -486,6 +486,32 @@ engine and CI/CD:
 - Try to search for error keywords in your message such as `error`, `failed`, `exception`, etc.
 - Read the error message closely to understand what's going on.
 
+## Sending logs to Unity Support
+
+When Unity Support asks for `Editor.log`, `Unity.Licensing.Client.log`,
+`Unity.Entitlements.Audit.log`, `services-config.json`, or any of the other Unity-internal log
+files, set `collectUnityLogs: true` on the `unity-builder` (or `unity-orchestrator`) step. The
+Orchestrator will gather every requested file into `Logs/UnityDiagnostics/` at the end of the
+build, regardless of platform, and emit a `manifest.json` describing what was captured.
+
+```yaml
+- uses: game-ci/unity-builder@v4
+  with:
+    targetPlatform: StandaloneLinux64
+    collectUnityLogs: true
+    streamUnityLogs: true # optional — live tail Editor.log to GHA log
+
+- if: always()
+  uses: actions/upload-artifact@v4
+  with:
+    name: unity-diagnostics
+    path: ${{ github.workspace }}/Logs/UnityDiagnostics/
+```
+
+Full list of categories, the per-platform path table, the live-streaming flag, and how to
+include sensitive files (license, etc.) is in
+[Unity Log Collection](/docs/github-orchestrator/advanced-topics/unity-log-collection).
+
 ## Still having problems?
 
 You can **search for existing issues**:


### PR DESCRIPTION
## Summary

Combines four open documentation PRs onto a single branch so they ship as one set:

- **#566** ` hotfix/remove-cli-remote-build-conflict ` — removes leftover conflict markers from ` docs/03-github-cli/03-remote-builds.mdx `
- **#565** ` docs/build-unity-image-discovery ` — surfaces the ` build-unity-image ` custom-image flow across the Docker docs (` 01-docker-images.mdx `, ` 03-customize-docker-images.mdx `, ` 05-custom-images.mdx `)
- **#567** ` docs/canonical-cache-and-self-hosted-lessons ` — canonical cache overlay strategy and self-hosted lessons in ` 03-github-orchestrator/07-advanced-topics/01-caching.mdx `
- **#568** ` docs/unity-log-collection ` — Unity diagnostic log collection feature documentation: new ` 22-unity-log-collection.mdx ` advanced-topics page + cross-links from ` 21-failures-and-diagnostics.mdx ` and ` 09-troubleshooting/common-issues.mdx ` (refs game-ci/unity-builder#740)

The four branches are independent — no overlapping files, no merge conflicts. Each is preserved as a merge commit in this branch's history so reviewers can drill into the original work.

## Why combine

These four small docs PRs all relate to the same May 2026 wave of orchestrator/CLI feature shipping (build-unity-image, canonical cache, Unity log collection) and reviewing them as one keeps the navigation/cross-link story coherent (e.g. the new Unity Log Collection page references the canonical cache / build reliability / engine-plugins pages that ship alongside).

## What this PR replaces

After merge, please close #565, #566, #567, #568 with a "superseded by #NNN" note pointing back here.

## Test plan

- [ ] Code formatting CI passes (oxfmt scoped to changed files)
- [ ] ` yarn build ` Docusaurus locally renders all four sets of changes without broken links
- [ ] Confirm the new ` /docs/github-orchestrator/advanced-topics/unity-log-collection ` route resolves
- [ ] Confirm cross-links from ` 21-failures-and-diagnostics.mdx ` and ` common-issues.mdx ` resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)