### PR TITLE
Improve personal license activation documentation

### DIFF
--- a/docs/03-github/02-activation.mdx
+++ b/docs/03-github/02-activation.mdx
@@ -51,6 +51,14 @@ Follow these steps if you are using the free version of Unity.
      alt="Unity Hub interface showing the Preferences window with the Licenses tab selected and the Add button highlighted"
    />
 
+   :::warning Personal License UI Variations
+
+   If you don't have the activation option to generate a `.ulf` license file, search in our
+   [game-ci Discord community](https://discord.gg/KcF25qStJU) where we have documented the best
+   approaches you can use.
+
+   :::
+
 4. **Locate the `.ulf` file**: Depending on your operating system, the Unity license file will be
    located in one of these paths:
    - Windows: `C:\ProgramData\Unity\Unity_lic.ulf`

--- a/docs/05-gitlab/02-activation.mdx
+++ b/docs/05-gitlab/02-activation.mdx
@@ -74,6 +74,14 @@ The activation process for Unity Personal licenses is as follows:
      alt="Unity Hub interface showing the Preferences window with the Licenses tab selected and the Add button highlighted"
    />
 
+   :::warning Personal License UI Variations
+
+   If you don't have the activation option to generate a `.ulf` license file, search in our
+   [game-ci Discord community](https://discord.gg/KcF25qStJU) where we have documented the best
+   approaches you can use.
+
+   :::
+
 4. **Locate the `.ulf` file**: Depending on your operating system, the Unity license file will be
    located in one of these paths:
    - Windows: `C:\ProgramData\Unity\Unity_lic.ulf`

--- a/docs/11-circleci/02-activation.mdx
+++ b/docs/11-circleci/02-activation.mdx
@@ -70,6 +70,14 @@ proceed to the following sub-section.
 2. Answer the prompted questions.
 3. Download the license file (Unity_v20XX.x.ulf).
 
+   :::warning License Activation UI Variations
+
+   If you don't have the activation option to generate a license file, search in our
+   [game-ci Discord community](https://discord.gg/KcF25qStJU) where we have documented the best
+   approaches you can use.
+
+   :::
+
 > _Note: It is fine if the version number in the file name does not match your exact Unity version._
 
 #### Encoding the license


### PR DESCRIPTION
## Summary

Improves personal license activation documentation by adding brief notices directing users to the Discord community when they don't have the activation option to generate a `.ulf` license file.

Multiple documented approaches exist in the community for handling different activation scenarios. These changes acknowledge that reality and guide users toward working solutions.

## Changes

- **GitHub activation docs** (`docs/03-github/02-activation.mdx`): Added UI variation notice
- **GitLab activation docs** (`docs/05-gitlab/02-activation.mdx`): Added UI variation notice
- **CircleCI activation docs** (`docs/11-circleci/02-activation.mdx`): Added UI variation notice

All notices direct to the [game-ci Discord community](https://discord.gg/KcF25qStJU).

## Test plan

- [ ] Docs render without errors
- [ ] Discord link is correct
- [ ] Tone is helpful and supportive

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated personal-license activation guidance for GitHub, GitLab, and CircleCI.
  - Added warnings that Unity’s activation interface may vary and may not offer `.ulf` file generation.
  - Included a link to the GameCI Discord community for alternative activation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->