### PR TITLE
Fix typos in test runner documentation

### DIFF
--- a/docs/03-github/03-test-runner.mdx
+++ b/docs/03-github/03-test-runner.mdx
@@ -116,7 +116,7 @@ the [`packageMode`](#packagemode) configuration option to `true`.
 
 When testing a Unity package that has dependencies inside a scoped registry, you can set the
 [`scopedRegistryUrl`](#scopedRegistryUrl) and [`registryScopes`](#registryScopes) to ensure those
-depedencies can be resolved.
+dependencies can be resolved.
 
 ```yaml
 - uses: game-ci/unity-test-runner@v4
@@ -128,7 +128,7 @@ depedencies can be resolved.
 #### Authentication with a private scoped registry
 
 If your package has dependencies that are hosted in a private UPM registry, then testing it is
-similar to tesing a project. Setup the [`scopedRegistryUrl`](#scopedRegistryUrl) and
+similar to testing a project. Setup the [`scopedRegistryUrl`](#scopedRegistryUrl) and
 [`registryScopes`](#registryScopes) as usual, but also include a `UPM_REGISTRY_TOKEN` when defining
 your Unity License.
 


### PR DESCRIPTION
#### Changes

- Added missing letter to "depedencies" typo in Test Runner documentation.
- Added missing letter to "tesing" typo in Test Runner documentation.

#### Checklist
- [x] Read the contribution [guide](../blob/main/CONTRIBUTING.md) and accept the
      [code](../blob/main/CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected spelling errors in the Unity package testing instructions.
  * No changes were made to configuration examples or other content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->