### PR TITLE
Unreal + Godot: image/runner guidance parity; fix stale FAQ recommendation

### DIFF
--- a/docs/03-github-cli/02-build.mdx
+++ b/docs/03-github-cli/02-build.mdx
@@ -143,12 +143,15 @@ Real Unreal Engine images are large, which affects where you can practically run
 | Community UE5 images (e.g. [ue5-docker](https://github.com/evoverses/ue5-docker)) | ~40 GB (from ~120 GB) | Self-built from your own UE license |
 | Full UE dev image                                                                 | 50-120 GB             | Rarely practical for CI             |
 
-GitHub-hosted runners have ~22GB free space by default (up to ~52GB with a disk-reclaim step like
-[jlumbroso/free-disk-space](https://github.com/jlumbroso/free-disk-space), or up to 150GB on paid
-larger runners) — even the smallest realistic UE image is tight or won't fit, and pulling a 35GB+
-image alone can take 10-20+ minutes. For anything beyond a quick smoke test, a **self-hosted
+Standard GitHub-hosted runners have ~22GB free space by default (up to ~52GB with a disk-reclaim
+step like [jlumbroso/free-disk-space](https://github.com/jlumbroso/free-disk-space)) — even the
+smallest realistic UE image is tight or won't fit there, and pulling a 35GB+ image alone can take
+10-20+ minutes. [Larger GitHub-hosted runners](https://docs.github.com/en/actions/using-github-hosted-runners/about-larger-runners/about-larger-runners)
+(a paid tier) scale storage with core count — from ~75GB on the smallest (2-core) size up to
+~2TB on the largest (64-core) — so they're a real option for UE images if you don't want to manage
+a self-hosted runner. For anything beyond a quick smoke test on a standard runner, a **self-hosted
 runner** with local image caching (so you're not re-pulling the image every run) is the practical
-choice. [unrealcontainers](https://unrealcontainers.com) is a good resource for building and
+default choice. [unrealcontainers](https://unrealcontainers.com) is a good resource for building and
 sizing your own image. See [Orchestrator's provider docs](/docs/github-orchestrator/providers/overview)
 for self-hosted and cloud provider options beyond plain GitHub-hosted runners.
 

--- a/docs/03-github-cli/02-build.mdx
+++ b/docs/03-github-cli/02-build.mdx
@@ -112,6 +112,14 @@ game-ci build ./my-godot-project \
 
 The default image tag uses the detected Godot version when available, otherwise `4.3`.
 
+### Choosing an image and a runner
+
+Unlike Unreal Engine (below), the default `barichello/godot-ci` image is small — an Ubuntu base
+plus standard build tooling, with Godot's editor and export templates fetched at build time rather
+than baked into a multi-GB image. Standard GitHub-hosted runners (~22GB free space by default)
+handle it comfortably; there's no need for a self-hosted runner or a larger-runner tier purely for
+image size the way there is for Unreal.
+
 ## Unreal Engine Commands
 
 Unreal Engine builds require a Docker image that you are licensed to use.

--- a/docs/03-github-cli/02-build.mdx
+++ b/docs/03-github-cli/02-build.mdx
@@ -133,6 +133,25 @@ The built-in command uses Unreal Automation Tool inside the container. The image
 `/home/ue4/UnrealEngine/Engine/Build/BatchFiles/RunUAT.sh`, or you should wrap your own Unreal
 workflow through a custom job or plugin.
 
+### Choosing an image and a runner
+
+Real Unreal Engine images are large, which affects where you can practically run this:
+
+| Image | Size | Notes |
+| --- | --- | --- |
+| `ghcr.io/epicgames/unreal-engine:dev-slim-5.4` | ~35 GB | Requires Epic GitHub org access |
+| Community UE5 images (e.g. [ue5-docker](https://github.com/evoverses/ue5-docker)) | ~40 GB (from ~120 GB) | Self-built from your own UE license |
+| Full UE dev image | 50-120 GB | Rarely practical for CI |
+
+GitHub-hosted runners have ~22GB free space by default (up to ~52GB with a disk-reclaim step like
+[jlumbroso/free-disk-space](https://github.com/jlumbroso/free-disk-space), or up to 150GB on paid
+larger runners) — even the smallest realistic UE image is tight or won't fit, and pulling a 35GB+
+image alone can take 10-20+ minutes. For anything beyond a quick smoke test, a **self-hosted
+runner** with local image caching (so you're not re-pulling the image every run) is the practical
+choice. [unrealcontainers](https://unrealcontainers.com) is a good resource for building and
+sizing your own image. See [Orchestrator's provider docs](/docs/github-orchestrator/providers/overview)
+for self-hosted and cloud provider options beyond plain GitHub-hosted runners.
+
 ## Test Command
 
 `game-ci test` is part of the CLI command model. The exact behavior and options are provided by the

--- a/docs/03-github-cli/02-build.mdx
+++ b/docs/03-github-cli/02-build.mdx
@@ -137,11 +137,11 @@ workflow through a custom job or plugin.
 
 Real Unreal Engine images are large, which affects where you can practically run this:
 
-| Image | Size | Notes |
-| --- | --- | --- |
-| `ghcr.io/epicgames/unreal-engine:dev-slim-5.4` | ~35 GB | Requires Epic GitHub org access |
+| Image                                                                             | Size                  | Notes                               |
+| --------------------------------------------------------------------------------- | --------------------- | ----------------------------------- |
+| `ghcr.io/epicgames/unreal-engine:dev-slim-5.4`                                    | ~35 GB                | Requires Epic GitHub org access     |
 | Community UE5 images (e.g. [ue5-docker](https://github.com/evoverses/ue5-docker)) | ~40 GB (from ~120 GB) | Self-built from your own UE license |
-| Full UE dev image | 50-120 GB | Rarely practical for CI |
+| Full UE dev image                                                                 | 50-120 GB             | Rarely practical for CI             |
 
 GitHub-hosted runners have ~22GB free space by default (up to ~52GB with a disk-reclaim step like
 [jlumbroso/free-disk-space](https://github.com/jlumbroso/free-disk-space), or up to 150GB on paid

--- a/docs/10-faq/index.mdx
+++ b/docs/10-faq/index.mdx
@@ -37,14 +37,20 @@ providers without changing the core workflow model.
 
 ### Recommendations for other game engines
 
-For **[Unreal Engine](https://unrealengine.com/)** users, it's worth checking out
-[unrealcontainers](https://unrealcontainers.com), a great resource created by our friend
-[Adam Rehn](https://adamrehn.com/).
+For **[Unreal Engine](https://unrealengine.com/)** and **[Godot](https://godotengine.org/)**, the
+[`game-ci` CLI](/docs/cli) has built-in engine detection and build/test commands for both — see
+[CLI Build Command](/docs/cli/build) for concrete examples (Unreal requires a Docker image you're
+licensed to use; Godot works out of the box against the community `barichello/godot-ci` image).
+Both also plug into [Orchestrator's engine-plugin interface](/docs/github-orchestrator/advanced-topics/engine-plugins)
+alongside Unity, for provider-backed builds across AWS/K8s/local/etc.
 
-For **[Godot](https://godotengine.org/)** developers, there are several options to consider. We
-recommend both [abarichello/godot-ci](https://github.com/abarichello/godot-ci) by
-[Artur Barichello](https://barichello.me/) and
-[firebelley/godot-export](https://github.com/firebelley/godot-export).
+For Unreal specifically, since real UE Docker images are large (30GB+) and typically require Epic
+org access or a self-built image from your own license, [unrealcontainers](https://unrealcontainers.com)
+(by our friend [Adam Rehn](https://adamrehn.com/)) is a great resource for building and sizing your
+own image before pointing `--custom-image` at it.
+
+For Godot, besides GameCI's own built-in support, [firebelley/godot-export](https://github.com/firebelley/godot-export)
+is also worth a look for GitHub Actions-native export workflows.
 
 **[MonoGame](https://www.monogame.net/)** enthusiasts should look at
 [Lean MonoGame - Automate Release](https://learn-monogame.github.io/how-to/automate-release/), an

--- a/docs/10-faq/index.mdx
+++ b/docs/10-faq/index.mdx
@@ -38,7 +38,7 @@ providers without changing the core workflow model.
 ### Recommendations for other game engines
 
 For **[Unreal Engine](https://unrealengine.com/)** and **[Godot](https://godotengine.org/)**, the
-[`game-ci` CLI](/docs/cli) has built-in engine detection and build/test commands for both — see
+[`game-ci` CLI](/docs/cli) has built-in engine detection and a build command for both — see
 [CLI Build Command](/docs/cli/build) for concrete examples (Unreal requires a Docker image you're
 licensed to use; Godot works out of the box against the community `barichello/godot-ci` image).
 Both also plug into [Orchestrator's engine-plugin interface](/docs/github-orchestrator/advanced-topics/engine-plugins)


### PR DESCRIPTION
Gives Unreal Engine docs parity with Godot, then closes the reverse gap too so both engines get the same category of guidance:

- `docs/10-faq/index.mdx` — rewrote "Recommendations for other game engines" to lead with game-ci's own CLI docs instead of only third-party resources.
- `docs/03-github-cli/02-build.mdx` — added a "Choosing an image and a runner" subsection under **Unreal Engine Commands** (image-size table, GitHub-runner disk-constraint guidance — UE images are 30GB+, standard runners have ~22GB free) and the equivalent under **Godot Commands** (much shorter: godot-ci's default image is small, standard runners are fine, no special guidance needed).

**Fixed during review:**
- The FAQ overclaimed "build/test commands" for Unreal/Godot via the `game-ci` CLI — checked `command-factory.ts` and both engine plugins, only a `build` command actually exists for either engine.
- The runner disk-space guidance understated GitHub's larger-runner tier ("up to 150GB") — that's only the 4-core size; the real range is ~75GB (2-core) to ~2TB (64-core), worth stating correctly since it's a real alternative for UE image sizing.

Verified: `docusaurus build` succeeds with no broken links, `oxfmt --check` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for choosing suitable images and runners for Godot and Unreal Engine builds.
  * Documented Unreal image size, storage, pull-time, licensing, and runner considerations.
  * Expanded FAQ guidance on Unreal and Godot build support, integrations, and related community resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->