### PR TITLE
Getting started: Quick start, prerequisites, troubleshooting links, platform picker

### DIFF
--- a/docs/03-github/01-getting-started.mdx
+++ b/docs/03-github/01-getting-started.mdx
@@ -8,6 +8,73 @@ GitHub [Actions for Unity](https://github.com/game-ci/unity-actions) provide the
 There are a few parts to setting up a workflow. Steps may slightly differ depending on each license
 type.
 
+## Quick start
+
+Copy this into `.github/workflows/main.yml` to test and build a WebGL project on every push. It's
+the same [Simple Example](#simple-example) shown again further down this page — this copy exists
+so there's something to paste before reading the rest of the page.
+
+```yaml
+name: Actions 😎
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Build my project ✨
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      # Cache
+      - uses: actions/cache@v3
+        with:
+          path: Library
+          key: Library-${{ hashFiles('Assets/**', 'Packages/**', 'ProjectSettings/**') }}
+          restore-keys: |
+            Library-
+
+      # Test
+      - name: Run tests
+        uses: game-ci/unity-test-runner@v4
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+
+      # Build
+      - name: Build project
+        uses: game-ci/unity-builder@v4
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+        with:
+          targetPlatform: WebGL
+
+      # Output
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Build
+          path: build
+```
+
+:::info Need `UNITY_LICENSE`, `UNITY_EMAIL`, or `UNITY_PASSWORD`?
+This example assumes you already have Unity activation secrets configured. If you don't yet, see
+[Activation](/docs/github/activation) first — it walks through personal, professional, and floating license
+setup.
+:::
+
+This example assumes your Unity project is in the root of your repository, and builds a single
+target (WebGL). More variations — Git LFS caching, parallel builds, multi-platform matrices — are
+in [Workflow examples](#workflow-examples) below.
+
 ## Mental model
 
 #### Overall steps

--- a/docs/03-github/01-getting-started.mdx
+++ b/docs/03-github/01-getting-started.mdx
@@ -1,4 +1,6 @@
 import Video from '../../src/components/video/video';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # Getting started
 
@@ -7,6 +9,14 @@ GitHub [Actions for Unity](https://github.com/game-ci/unity-actions) provide the
 
 There are a few parts to setting up a workflow. Steps may slightly differ depending on each license
 type.
+
+## Prerequisites
+
+- A Unity project, checked into a GitHub repository
+- A Unity license — personal, plus, pro, or a Unity Personal serial (see
+  [Activation](/docs/github/activation) for how to obtain and configure one)
+- Familiarity with [GitHub Actions](https://docs.github.com/en/actions) basics (a `.github/workflows`
+  YAML file, jobs, and steps) — if this is new to you, read the note below first
 
 ## Mental model
 
@@ -47,13 +57,57 @@ Any subsequent steps assume you have read the above.
 Unity Actions are using [game-ci/docker](https://github.com/game-ci/docker/) since `unity-builder`
 version 2. Any version in this [list](/docs/docker/versions) can be used.
 
-## Video Tutorial
+### Something not working?
 
-<Video url="https://www.youtube-nocookie.com/embed/M2BZr02uai0" />
+- Check [Common issues](/docs/troubleshooting/common-issues) — activation failures, license errors,
+  and other problems reported most often.
+- Check the [FAQ](/docs/faq) for answers to general questions about GameCI.
 
-_Note: The video tutorial was created using an earlier version of the GameCI GitHub Actions for
-Unity. While it provides a helpful visual guide to understanding the process, please refer to the
-current documentation on this website for the most up-to-date information._
+## Choosing a target platform
+
+The examples below default to `WebGL`, but `targetPlatform` accepts any value from the
+[supported platforms list](/docs/github/builder#targetplatform). A few common ones:
+
+<Tabs>
+  <TabItem value="webgl" label="WebGL" default>
+
+```yaml
+- uses: game-ci/unity-builder@v4
+  with:
+    targetPlatform: WebGL
+```
+
+  </TabItem>
+  <TabItem value="windows" label="Windows">
+
+```yaml
+- uses: game-ci/unity-builder@v4
+  with:
+    targetPlatform: StandaloneWindows64
+```
+
+  </TabItem>
+  <TabItem value="linux" label="Linux">
+
+```yaml
+- uses: game-ci/unity-builder@v4
+  with:
+    targetPlatform: StandaloneLinux64
+```
+
+  </TabItem>
+  <TabItem value="android" label="Android">
+
+```yaml
+- uses: game-ci/unity-builder@v4
+  with:
+    targetPlatform: Android
+```
+
+  </TabItem>
+</Tabs>
+
+Swap the `targetPlatform` line into any of the full examples below.
 
 ## Workflow examples
 
@@ -441,3 +495,12 @@ jobs:
           name: Build
           path: build
 ```
+
+## Video Tutorial
+
+<Video url="https://www.youtube-nocookie.com/embed/M2BZr02uai0" />
+
+_This video was recorded using an earlier version of the GameCI GitHub Actions for Unity — some
+details (action versions, `Cache` step syntax) are outdated. Treat it as a conceptual walkthrough
+of the overall flow, not a copy-paste reference; the [Simple example](#simple-example) above and
+the [Activation](/docs/github/activation) page reflect the current setup._


### PR DESCRIPTION
Unified PR for the full getting-started audit from [game-ci/roadmap#8](https://github.com/game-ci/roadmap/issues/8#issuecomment-5273011258) (previously split across this PR and #581 — merged together since they're both edits to the same audit of the same page):

1. **Quick start** — a copy-paste workflow snippet above the fold, right after the intro (duplicating, not moving, the Simple Example YAML so the existing `#simple-example` anchor stays intact elsewhere on the site), with an inline `:::info` callout linking to Activation.
2. **Prerequisites** — explicit list up top (project, license, GitHub Actions familiarity), leading the page — matches the structure of the orchestrator's own getting-started page.
3. **Inline troubleshooting/FAQ links** — `docs/09-troubleshooting/common-issues.mdx` and `docs/10-faq/index.mdx` both already existed but weren't linked from anywhere in the getting-started tree; added a "Something not working?" subsection under Support.
4. **Platform picker** — a `Tabs` block (WebGL/Windows/Linux/Android) showing just the differing `targetPlatform` line, linking to the full reference on the builder page.
5. **Video re-caption + reposition** — moved the outdated video tutorial from directly under Support to the very end of the page, with a caption that specifically flags what's outdated (action versions, Cache step syntax) and points at the current Simple example + Activation page.

Verified: `docusaurus build` succeeds with no new broken links, `oxfmt --check` passes.

~~Draft~~ — flagging in particular that the platform-picker tabs (item 4) were called out as the most opinionated item in the original proposal; happy to drop that piece if reviewers disagree with the added complexity.
