### PR TITLE
docs: document cli's new build options, --recipe, and test-runner's coverageEnabled

### DIFF
--- a/docs/03-github-cli/02-build.mdx
+++ b/docs/03-github-cli/02-build.mdx
@@ -152,22 +152,25 @@ game-ci test ./my-project
 ### Unity
 
 For Unity projects, `game-ci test` runs Unity's own official test runner (part of the
-[Unity CLI](https://docs.unity.com/en-us/unity-cli), released by Unity in 2025 and still marked
-experimental) directly against the installed editor - it is not a reimplementation and does not
-replace `game-ci/unity-test-runner`'s custom NUnit harness (package-mode testing, code coverage,
-scoped registries).
+[Unity CLI](https://docs.unity.com/en-us/unity-cli), first released by Unity in April 2026 and
+still marked experimental) directly against the installed editor - it is not a reimplementation
+and does not replace `game-ci/unity-test-runner`'s custom NUnit harness (package-mode testing,
+code coverage, scoped registries).
 
 | Option             | Default | Description                                            |
 | ------------------ | ------- | ------------------------------------------------------ |
 | `--unity-cli-args` | empty   | Raw arguments passed straight through to `unity test`. |
 
 `--unity-cli-args` is a raw pass-through rather than typed flags, because Unity's own CLI reference
-documents `test` with a one-line description and no published flag table - `unity test --help` on
-the installed binary is the only authoritative reference, per Unity's own docs. Hardcoding guessed
-flag names would mean shipping unverified assumptions.
+page documents `test` with a one-line description and no formal parameter table, pointing to
+`unity test --help` on the installed binary as the authoritative source instead. Hardcoding guessed
+flag names would mean shipping unverified assumptions. Unity's release notes do name specific flags
+added to `test` over time (`--mode`, `--output`, `--filter`, `--editor-version`, `--editor-path`,
+`--architecture`, `--allow-install`, `--timeout` as of CLI `0.1.0-beta.7`) - treat these as a
+starting point, not a guarantee for your installed version; confirm with `--help`.
 
 ```bash
-game-ci test ./my-unity-project --unity-cli-args "--platform editmode --report results.xml"
+game-ci test ./my-unity-project --unity-cli-args "--mode editmode --output results.xml"
 ```
 
 For engines or projects that need a different test runner, use a plugin-provided test command, a

--- a/docs/03-github-cli/02-build.mdx
+++ b/docs/03-github-cli/02-build.mdx
@@ -32,29 +32,29 @@ game-ci build ./my-unity-project \
 
 Common Unity options:
 
-| Option                     | Default                                   | Description                                   |
-| -------------------------- | ----------------------------------------- | --------------------------------------------- |
-| `--target-platform`, `-t`  | `StandaloneLinux64`                       | Unity target platform.                        |
-| `--build-name`             | target platform                           | Output build name.                            |
-| `--builds-path`, `-o`      | `build`                                   | Output folder for builds.                     |
-| `--build-method`, `-m`     | `UnityBuilderAction.Builder.BuildProject` | Static build method to run.                   |
-| `--custom-image`           | GameCI Unity editor image                 | Override the Docker image.                    |
-| `--custom-parameters`      | empty                                     | Extra arguments passed to Unity.              |
-| `--docker-workspace-path`  | `/github/workspace`                       | Container mount path for the workspace.       |
-| `--unity-email`, `-u`      | empty                                     | Unity account email.                          |
-| `--unity-password`, `-p`   | empty                                     | Unity account password.                       |
-| `--unity-serial`, `-s`     | empty                                     | Unity Pro or Plus serial.                     |
-| `--unity-license`, `-l`    | empty                                     | Contents of, or path to, a Unity `.ulf` file. |
-| `--unity-licensing-server` | empty                                     | Unity floating licensing server.              |
-| `--ssh-agent`              | empty                                     | SSH agent path to forward into the container. |
-| `--git-private-token`      | empty                                     | Token used for private Git dependencies.      |
-| `--chown-files-to`         | empty                                     | User or user:group for build artifact owner.  |
-| `--build-profile`          | empty                                     | Path to a Unity 6 Build Profile asset (relative to the project). When set, this determines the build's target instead of `--target-platform`. |
+| Option                     | Default                                   | Description                                                                                                                                                                                                                                                               |
+| -------------------------- | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--target-platform`, `-t`  | `StandaloneLinux64`                       | Unity target platform.                                                                                                                                                                                                                                                    |
+| `--build-name`             | target platform                           | Output build name.                                                                                                                                                                                                                                                        |
+| `--builds-path`, `-o`      | `build`                                   | Output folder for builds.                                                                                                                                                                                                                                                 |
+| `--build-method`, `-m`     | `UnityBuilderAction.Builder.BuildProject` | Static build method to run.                                                                                                                                                                                                                                               |
+| `--custom-image`           | GameCI Unity editor image                 | Override the Docker image.                                                                                                                                                                                                                                                |
+| `--custom-parameters`      | empty                                     | Extra arguments passed to Unity.                                                                                                                                                                                                                                          |
+| `--docker-workspace-path`  | `/github/workspace`                       | Container mount path for the workspace.                                                                                                                                                                                                                                   |
+| `--unity-email`, `-u`      | empty                                     | Unity account email.                                                                                                                                                                                                                                                      |
+| `--unity-password`, `-p`   | empty                                     | Unity account password.                                                                                                                                                                                                                                                   |
+| `--unity-serial`, `-s`     | empty                                     | Unity Pro or Plus serial.                                                                                                                                                                                                                                                 |
+| `--unity-license`, `-l`    | empty                                     | Contents of, or path to, a Unity `.ulf` file.                                                                                                                                                                                                                             |
+| `--unity-licensing-server` | empty                                     | Unity floating licensing server.                                                                                                                                                                                                                                          |
+| `--ssh-agent`              | empty                                     | SSH agent path to forward into the container.                                                                                                                                                                                                                             |
+| `--git-private-token`      | empty                                     | Token used for private Git dependencies.                                                                                                                                                                                                                                  |
+| `--chown-files-to`         | empty                                     | User or user:group for build artifact owner.                                                                                                                                                                                                                              |
+| `--build-profile`          | empty                                     | Path to a Unity 6 Build Profile asset (relative to the project). When set, this determines the build's target instead of `--target-platform`.                                                                                                                             |
 | `--manual-exit`            | `false`                                   | Skip passing `-quit` to the editor, so it stays open after the build method returns. Your build method must call `EditorApplication.Exit(0)` itself, otherwise the build hangs until it times out. Use this if your build method needs to enter play mode before exiting. |
-| `--skip-activation`        | `false`                                   | Skip the license activation and return-license steps entirely. Useful when a license is already active in a long-lived container. |
-| `--run-as-host-user`       | `false`                                   | Linux only. Run the build as a user matching the host's UID/GID instead of the container's default root user, so build artifacts aren't left root-owned on the host. |
-| `--enable-gpu`             | `false`                                   | Windows only. Installs a Mesa llvmpipe software graphics driver before the build, for GPU-less compute-shader/graphics testing. |
-| `--git-config-extensions`  | empty                                     | Linux only. Newline-separated list of extra git config entries in `key=value` form (e.g. for LFS/submodule auth setups `--git-private-token` doesn't cover). |
+| `--skip-activation`        | `false`                                   | Skip the license activation and return-license steps entirely. Useful when a license is already active in a long-lived container.                                                                                                                                         |
+| `--run-as-host-user`       | `false`                                   | Linux only. Run the build as a user matching the host's UID/GID instead of the container's default root user, so build artifacts aren't left root-owned on the host.                                                                                                      |
+| `--enable-gpu`             | `false`                                   | Windows only. Installs a Mesa llvmpipe software graphics driver before the build, for GPU-less compute-shader/graphics testing.                                                                                                                                           |
+| `--git-config-extensions`  | empty                                     | Linux only. Newline-separated list of extra git config entries in `key=value` form (e.g. for LFS/submodule auth setups `--git-private-token` doesn't cover).                                                                                                              |
 
 On Linux and Windows, Unity builds run through Docker. On macOS, the CLI uses the host Unity
 installation path handled by the macOS builder setup. `--run-as-host-user` and
@@ -157,9 +157,9 @@ experimental) directly against the installed editor - it is not a reimplementati
 replace `game-ci/unity-test-runner`'s custom NUnit harness (package-mode testing, code coverage,
 scoped registries).
 
-| Option              | Default | Description                                                   |
-| -------------------- | ------- | --------------------------------------------------------------- |
-| `--unity-cli-args`   | empty   | Raw arguments passed straight through to `unity test`.         |
+| Option             | Default | Description                                            |
+| ------------------ | ------- | ------------------------------------------------------ |
+| `--unity-cli-args` | empty   | Raw arguments passed straight through to `unity test`. |
 
 `--unity-cli-args` is a raw pass-through rather than typed flags, because Unity's own CLI reference
 documents `test` with a one-line description and no published flag table - `unity test --help` on

--- a/docs/03-github-cli/02-build.mdx
+++ b/docs/03-github-cli/02-build.mdx
@@ -49,9 +49,16 @@ Common Unity options:
 | `--ssh-agent`              | empty                                     | SSH agent path to forward into the container. |
 | `--git-private-token`      | empty                                     | Token used for private Git dependencies.      |
 | `--chown-files-to`         | empty                                     | User or user:group for build artifact owner.  |
+| `--build-profile`          | empty                                     | Path to a Unity 6 Build Profile asset (relative to the project). When set, this determines the build's target instead of `--target-platform`. |
+| `--manual-exit`            | `false`                                   | Skip passing `-quit` to the editor, so it stays open after the build method returns. Your build method must call `EditorApplication.Exit(0)` itself, otherwise the build hangs until it times out. Use this if your build method needs to enter play mode before exiting. |
+| `--skip-activation`        | `false`                                   | Skip the license activation and return-license steps entirely. Useful when a license is already active in a long-lived container. |
+| `--run-as-host-user`       | `false`                                   | Linux only. Run the build as a user matching the host's UID/GID instead of the container's default root user, so build artifacts aren't left root-owned on the host. |
+| `--enable-gpu`             | `false`                                   | Windows only. Installs a Mesa llvmpipe software graphics driver before the build, for GPU-less compute-shader/graphics testing. |
+| `--git-config-extensions`  | empty                                     | Linux only. Newline-separated list of extra git config entries in `key=value` form (e.g. for LFS/submodule auth setups `--git-private-token` doesn't cover). |
 
 On Linux and Windows, Unity builds run through Docker. On macOS, the CLI uses the host Unity
-installation path handled by the macOS builder setup.
+installation path handled by the macOS builder setup. `--run-as-host-user` and
+`--git-config-extensions` are Linux-only; `--enable-gpu` is Windows-only.
 
 ### Custom Unity Methods
 
@@ -142,8 +149,29 @@ detected engine plugin, so test support can evolve per engine without changing t
 game-ci test ./my-project
 ```
 
-For engines or projects that need a custom test runner, use a plugin-provided test command, a Unity
-custom method, or a remote custom job.
+### Unity
+
+For Unity projects, `game-ci test` runs Unity's own official test runner (part of the
+[Unity CLI](https://docs.unity.com/en-us/unity-cli), released by Unity in 2025 and still marked
+experimental) directly against the installed editor - it is not a reimplementation and does not
+replace `game-ci/unity-test-runner`'s custom NUnit harness (package-mode testing, code coverage,
+scoped registries).
+
+| Option              | Default | Description                                                   |
+| -------------------- | ------- | --------------------------------------------------------------- |
+| `--unity-cli-args`   | empty   | Raw arguments passed straight through to `unity test`.         |
+
+`--unity-cli-args` is a raw pass-through rather than typed flags, because Unity's own CLI reference
+documents `test` with a one-line description and no published flag table - `unity test --help` on
+the installed binary is the only authoritative reference, per Unity's own docs. Hardcoding guessed
+flag names would mean shipping unverified assumptions.
+
+```bash
+game-ci test ./my-unity-project --unity-cli-args "--platform editmode --report results.xml"
+```
+
+For engines or projects that need a different test runner, use a plugin-provided test command, a
+Unity custom method via `game-ci build --build-method`, or a remote custom job.
 
 ## Versioning
 

--- a/docs/03-github/03-test-runner.mdx
+++ b/docs/03-github/03-test-runner.mdx
@@ -371,6 +371,17 @@ In this folder a folder will be created for every test mode.
 
 _**required:** `false`_ _**default:** `artifacts`_
 
+#### coverageEnabled
+
+Whether to pass `-enableCodeCoverage` to the Unity editor at all. Code coverage instrumentation is
+on by default, matching earlier behavior, but it has been the root cause of crashes and compile
+errors on some Unity versions (obsolete-API-as-error issues in `com.unity.testtools.codecoverage`,
+and a PlayMode SIGSEGV on Unity 6). If your tests hang, crash, or fail to compile only when coverage
+is enabled, set this to `false` to isolate the issue - the run will still complete, just without
+coverage results.
+
+_**required:** `false`_ _**default:** `true`_
+
 #### coverageOptions
 
 Options for configuring code coverage, this configures the `-coverageOptions` parameter described

--- a/docs/08-docker/05-custom-images.mdx
+++ b/docs/08-docker/05-custom-images.mdx
@@ -54,9 +54,45 @@ game-ci build-unity-image [baseOs] [modules] [options]
 | `--push`          | `false`            | Push image to registry after building     |
 | `--hub-image`     | `unityci/hub`      | Hub base image                            |
 | `--base-image`    | `unityci/base`     | Editor base image                         |
+| `--recipe`        | empty               | Path to a YAML recipe file (see below)   |
 
 The CLI also supports `baseOs=windows`. When you select `windows`, the command uses the Windows
 Hub and base image defaults unless you override them with `--hub-image` and `--base-image`.
+
+### Recipe Files
+
+Instead of passing every setting as a CLI flag, you can check a declarative, diffable recipe file
+into your repository and pass it with `--recipe`:
+
+```yaml
+# recipe.yml
+unityVersion: 2022.3.20f1
+baseOs: ubuntu
+modules:
+  - windows-mono
+  - linux-il2cpp
+changeset: abc123
+tag: ghcr.io/my-org/unity-editor:desktop
+```
+
+```bash
+game-ci build-unity-image --recipe recipe.yml
+```
+
+**Recipe fields take priority over CLI flags for the same setting when both are given** - the
+recipe file is meant to be the committed, reviewed source of truth for a build; flags are treated
+as one-off overrides layered on top of whatever the recipe doesn't specify.
+
+| Field          | Maps to           |
+| --------------- | ------------------ |
+| `unityVersion`  | `--unity-version`  |
+| `baseOs`        | positional `baseOs` argument |
+| `modules`       | positional `modules` argument (list instead of comma-separated string) |
+| `changeset`     | `--changeset`      |
+| `hubImage`      | `--hub-image`      |
+| `baseImage`     | `--base-image`     |
+| `tag`           | `--tag`            |
+| `engine`        | must be `unity` or omitted |
 
 ### Available Modules
 

--- a/docs/08-docker/05-custom-images.mdx
+++ b/docs/08-docker/05-custom-images.mdx
@@ -54,7 +54,7 @@ game-ci build-unity-image [baseOs] [modules] [options]
 | `--push`          | `false`            | Push image to registry after building     |
 | `--hub-image`     | `unityci/hub`      | Hub base image                            |
 | `--base-image`    | `unityci/base`     | Editor base image                         |
-| `--recipe`        | empty               | Path to a YAML recipe file (see below)   |
+| `--recipe`        | empty              | Path to a YAML recipe file (see below)    |
 
 The CLI also supports `baseOs=windows`. When you select `windows`, the command uses the Windows
 Hub and base image defaults unless you override them with `--hub-image` and `--base-image`.
@@ -83,16 +83,16 @@ game-ci build-unity-image --recipe recipe.yml
 recipe file is meant to be the committed, reviewed source of truth for a build; flags are treated
 as one-off overrides layered on top of whatever the recipe doesn't specify.
 
-| Field          | Maps to           |
-| --------------- | ------------------ |
-| `unityVersion`  | `--unity-version`  |
-| `baseOs`        | positional `baseOs` argument |
-| `modules`       | positional `modules` argument (list instead of comma-separated string) |
-| `changeset`     | `--changeset`      |
-| `hubImage`      | `--hub-image`      |
-| `baseImage`     | `--base-image`     |
-| `tag`           | `--tag`            |
-| `engine`        | must be `unity` or omitted |
+| Field          | Maps to                                                                |
+| -------------- | ---------------------------------------------------------------------- |
+| `unityVersion` | `--unity-version`                                                      |
+| `baseOs`       | positional `baseOs` argument                                           |
+| `modules`      | positional `modules` argument (list instead of comma-separated string) |
+| `changeset`    | `--changeset`                                                          |
+| `hubImage`     | `--hub-image`                                                          |
+| `baseImage`    | `--base-image`                                                         |
+| `tag`          | `--tag`                                                                |
+| `engine`       | must be `unity` or omitted                                             |
 
 ### Available Modules
 

--- a/docs/08-docker/05-custom-images.mdx
+++ b/docs/08-docker/05-custom-images.mdx
@@ -94,6 +94,10 @@ as one-off overrides layered on top of whatever the recipe doesn't specify.
 | `tag`          | `--tag`                                                                |
 | `engine`       | must be `unity` or omitted                                             |
 
+`--push` is not a recipe field - whether to push after building is a per-invocation decision, not
+a property of the build itself, so it must be passed as a CLI flag on every invocation regardless
+of whether you're using a recipe.
+
 ### Available Modules
 
 | Module         | Description                       |

--- a/docs/08-docker/05-custom-images.mdx
+++ b/docs/08-docker/05-custom-images.mdx
@@ -46,15 +46,15 @@ game-ci build-unity-image [baseOs] [modules] [options]
 
 ### Options
 
-| Flag              | Default            | Description                               |
-| ----------------- | ------------------ | ----------------------------------------- |
-| `--unity-version` | _(required)_       | Unity editor version (e.g. `2022.3.20f1`) |
-| `--changeset`     | _(auto-resolved)_  | Unity changeset hash                      |
-| `--tag`           | _(auto-generated)_ | Docker image tag                          |
-| `--push`          | `false`            | Push image to registry after building     |
-| `--hub-image`     | `unityci/hub`      | Hub base image                            |
-| `--base-image`    | `unityci/base`     | Editor base image                         |
-| `--recipe`        | empty              | Path to a YAML recipe file (see below)    |
+| Flag              | Default                                    | Description                               |
+| ----------------- | ------------------------------------------ | ----------------------------------------- |
+| `--unity-version` | _(required unless provided by `--recipe`)_ | Unity editor version (e.g. `2022.3.20f1`) |
+| `--changeset`     | _(auto-resolved)_                          | Unity changeset hash                      |
+| `--tag`           | _(auto-generated)_                         | Docker image tag                          |
+| `--push`          | `false`                                    | Push image to registry after building     |
+| `--hub-image`     | `unityci/hub`                              | Hub base image                            |
+| `--base-image`    | `unityci/base`                             | Editor base image                         |
+| `--recipe`        | empty                                      | Path to a YAML recipe file (see below)    |
 
 The CLI also supports `baseOs=windows`. When you select `windows`, the command uses the Windows
 Hub and base image defaults unless you override them with `--hub-image` and `--base-image`.
@@ -66,6 +66,7 @@ into your repository and pass it with `--recipe`:
 
 ```yaml
 # recipe.yml
+version: 1
 unityVersion: 2022.3.20f1
 baseOs: ubuntu
 modules:
@@ -85,6 +86,7 @@ as one-off overrides layered on top of whatever the recipe doesn't specify.
 
 | Field          | Maps to                                                                |
 | -------------- | ---------------------------------------------------------------------- |
+| `version`      | recipe format version (currently `1`) - no CLI flag equivalent         |
 | `unityVersion` | `--unity-version`                                                      |
 | `baseOs`       | positional `baseOs` argument                                           |
 | `modules`      | positional `modules` argument (list instead of comma-separated string) |


### PR DESCRIPTION
Reviewed the docs against this session's landed cli/unity-test-runner changes and found real, worth-fixing gaps rather than assuming everything was already covered.

## cli build command

Six new options had zero documentation footprint: `--build-profile`, `--manual-exit`, `--skip-activation`, `--run-as-host-user`, `--enable-gpu`, `--git-config-extensions` (game-ci/cli#62, #67).

## `game-ci test`'s Unity support

The doc described it vaguely as "provided by the detected engine plugin." It now has a real, concrete implementation (game-ci/cli#59) — Unity's own native CLI test runner via `--unity-cli-args` — worth describing directly instead of deferring entirely to a plugin abstraction. Explained why it's a raw pass-through rather than typed flags (Unity's own docs point to `unity test --help` as the only authoritative reference).

## `build-unity-image --recipe`

A fully implemented, real feature (game-ci/cli#56/#61) — a declarative YAML recipe file, with recipe fields taking priority over CLI flags — had no documentation at all.

## unity-test-runner's `coverageEnabled`

New opt-out input (game-ci/unity-test-runner#311) added specifically to work around real coverage-instrumentation crashes/compile errors on some Unity versions. It was undocumented, meaning the exact users who'd need it had no way to discover it.

## Verification

`yarn build` — compiles clean, no new broken links or routes (the pre-existing "duplicate routes" warning for `/docs/docker/versions` is unrelated to this change).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded Unity CLI build guidance with build profiles, license handling, editor exit controls, host-user execution, Windows GPU support, Git configuration, and platform restrictions.
  - Documented `game-ci test`, Unity’s experimental test runner, raw CLI argument support, and custom test runner alternatives.
  - Added guidance for disabling code coverage when it causes test failures; coverage remains enabled by default.
  - Documented YAML recipes and the `--recipe` option for custom Unity image builds, including recipe settings taking priority over CLI flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->