### PR TITLE
docs: clarify targetPlatform/runs-on OS mapping, Mono vs IL2CPP, unityVersion syntax

### DIFF
--- a/docs/03-github/04-builder.mdx
+++ b/docs/03-github/04-builder.mdx
@@ -138,12 +138,46 @@ Platform that the build should target.
 Must be one of the [allowed values](https://docs.unity3d.com/ScriptReference/BuildTarget.html)
 listed in the Unity scripting manual.
 
-_**required:** `true`_
+_**required:** `true`_ _**example:** `StandaloneWindows64`_
+
+**`targetPlatform` determines which `runs-on` OS you need.** The Docker image `unity-builder`
+uses is Linux-only, so any target that isn't natively buildable from Linux runs on that target's
+own OS instead. There's no way to build, say, `StandaloneWindows64` from an `ubuntu-latest`
+runner - use the table below to pick the right `runs-on` for the platform(s) you're building.
+
+| `runs-on`       | `targetPlatform` values it supports                             |
+| --------------- | --------------------------------------------------------------- |
+| `ubuntu-latest` | `StandaloneLinux64`, `iOS`, `Android`, `WebGL`                  |
+| `windows-2022`  | `StandaloneWindows`, `StandaloneWindows64`, `tvOS`, `WSAPlayer` |
+| `macos-latest`  | `StandaloneOSX`                                                 |
+
+Building for multiple platforms in one workflow means multiple jobs (or a matrix with an
+OS-appropriate `runs-on`) - see the
+[Advanced IL2CPP example](/docs/github/getting-started#advanced-il2cpp-example), which is really a
+multi-platform, multi-OS matrix example (IL2CPP is incidental to it - see the note below).
+
+**Mono vs IL2CPP** isn't a `unity-builder` input at all - there's no `scriptingBackend` field.
+It's a Unity Player Settings choice (`Project Settings > Player > Other Settings > Scripting
+Backend`), baked into your project before the build ever runs, the same way it would be for a
+local build in the Editor. `unity-builder` just builds whatever your project is already
+configured to build. The one thing that _is_ project-adjacent to this action: IL2CPP builds
+require the base OS to match the build target (same table as above) - there's no cross-compiling
+IL2CPP for Windows from a Linux runner, for example.
 
 #### unityVersion
 
 Version of Unity to use for building the project. Use "auto" to get from your
 ProjectSettings/ProjectVersion.txt
+
+The exact string from Unity Hub/the editor's own version display, including the release tag
+letter and build number - e.g. `2021.3.16f1`, `2022.3.7f1`, `6000.0.23f1`. Not just the numeric
+part (`2021.3.16` alone will not resolve).
+
+```yaml
+- uses: game-ci/unity-builder@v4
+  with:
+    unityVersion: 2021.3.16f1
+```
 
 _**required:** `false`_ _**default:** `auto`_
 


### PR DESCRIPTION
Prompted by Discord feedback from a new user (paraphrased): the docs and tutorial are great, but it was hard to piece together things like which `runs-on` OS to use, what `targetPlatform` values exist and whether they need a specific OS, how Mono vs IL2CPP works, and the exact `unityVersion` syntax — "a lot of this is explained through the docs but it's sometimes hard to understand how to use them properly... adding maybe some examples could help."

Checked: the information mostly existed, just scattered — `getting-started.mdx` has three separate per-OS example jobs (Linux/Windows/macOS) that implicitly show which platforms go where, but there's no single stated rule. Mono vs IL2CPP wasn't addressed as its own topic anywhere (no `scriptingBackend` input exists — grepped the whole repo to confirm).

## Changes to `docs/03-github/04-builder.mdx`

- **`targetPlatform` → `runs-on` table**, placed directly under the input description: which `runs-on` OS supports which `targetPlatform` values, since there's genuinely no way to build e.g. `StandaloneWindows64` from `ubuntu-latest` (the Docker image is Linux-only) — this was previously only reconstructable by diffing three separate example jobs in `getting-started.mdx`.
- **Mono vs IL2CPP note**: clarifies it's a Unity Player Settings choice (`Project Settings > Player > Other Settings > Scripting Backend`), not a `unity-builder` input — cross-links to the existing "Advanced IL2CPP example" (which is really a multi-platform matrix example) instead of duplicating it.
- **`unityVersion` concrete example** (`2021.3.16f1`) plus a note that the exact editor version string is required, not just the numeric part (a `2021.3.16` alone won't resolve).

## Testing

- `yarn build` (Docusaurus) succeeds with no broken-link warnings — specifically verified the new `/docs/github/getting-started#advanced-il2cpp-example` cross-link resolves.
- `oxfmt --check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that `targetPlatform` is required and documented supported operating systems.
  * Added guidance for configuring multi-platform workflows and Mono/IL2CPP builds.
  * Clarified that `unityVersion` must include the exact editor version, release tag, and build number.
  * Added a `unityVersion` usage example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->