### PR TITLE
docs(cli): document the new experimental deploy/QA plugins

### DIFF
--- a/docs/03-github-cli/06-experimental-plugins.mdx
+++ b/docs/03-github-cli/06-experimental-plugins.mdx
@@ -1,0 +1,85 @@
+---
+sidebar_position: 6
+slug: /cli/experimental-plugins
+---
+
+# Experimental Plugins
+
+These CLI plugins are functional but new, not published to npm, and not loaded by default - opt in
+with `--plugin <name>`. Expect rough edges, and verify against a test target (a test repo, a test
+itch.io channel) before pointing any of them at something real.
+
+## Deploy to a GitHub Release
+
+`@game-ci/github-release-deploy` attaches a built output to a GitHub Release.
+
+```bash
+GITHUB_TOKEN=... game-ci \
+  --plugin @game-ci/github-release-deploy \
+  deploy github-release ./build --repo owner/repo --tag v1.2.3
+```
+
+`buildPath` may be a single file (uploaded as-is, optionally renamed via `--assetName`) or a
+directory - every top-level file inside it is uploaded as a separate asset, named after itself.
+Re-running against the same tag is idempotent: an existing release for that tag is reused, and an
+asset that already exists on it is replaced rather than failing.
+
+| Option              | Description                                                         |
+| -------------------- | -------------------------------------------------------------------- |
+| `--repo`             | `owner/repo`. Defaults to `$GITHUB_REPOSITORY`.                     |
+| `--tag`              | Release tag. Required.                                              |
+| `--releaseNotes`     | Release body/description.                                           |
+| `--draft`            | Create the release as a draft.                                      |
+| `--prerelease`       | Mark the release as a prerelease.                                   |
+| `--assetName`        | Override the uploaded asset's file name (single-file buildPath only). |
+| `--targetCommitish`  | Commit/branch to create the tag from, if it doesn't already exist.  |
+
+GitLab Release support isn't included in this first version.
+
+## Deploy to itch.io
+
+`@game-ci/itch-deploy` wraps itch.io's official `butler push` CLI.
+
+```bash
+BUTLER_API_KEY=... game-ci \
+  --plugin @game-ci/itch-deploy \
+  deploy itch ./build --user myuser --game mygame --channel windows
+```
+
+Requires `butler` already installed and on `PATH` (or pass `--butlerPath` explicitly - recommended
+for CI determinism). This plugin doesn't install butler for you.
+
+| Option          | Description                                                                 |
+| ----------------- | ---------------------------------------------------------------------------- |
+| `--user`         | itch.io username or organization. Required.                                 |
+| `--game`         | itch.io game slug. Required.                                                |
+| `--channel`      | Channel to push to, e.g. `windows`, `linux`, `web`. Required.               |
+| `--butlerPath`   | Explicit path to the butler executable.                                     |
+| `--userVersion`  | Custom version string shown in itch.io's build history.                     |
+| `--ignore`       | Comma-separated glob patterns excluded from the push.                       |
+
+## Pseudo-localization QA
+
+`@game-ci/pseudo-localization` injects pseudo-loc strings pre-translation, to catch UI
+overflow/truncation and missing-localization bugs before real translation work starts.
+
+```bash
+game-ci --plugin @game-ci/pseudo-localization pseudo-localize ./Localization
+```
+
+Reads a flat key→string localization table - `<projectPath>/<sourceLocale>.json` or `.csv` - and
+writes the pseudo-localized result to `<projectPath>/<outputLocale>.<same format>`. Engine-specific
+structured formats (e.g. Unity's binary StringTable assets) aren't supported yet; export through a
+flat table as an intermediate step if your project uses one.
+
+The transform combines three techniques: accented-character substitution (so any string that skips
+the pipeline stands out), length expansion (`--expansionFactor`, default `1.3` - most languages run
+30-50% longer than English), and bracket markers around each string (catches concatenation bugs).
+Format placeholders (`{0}`, `%s`) and simple markup (`<b>...</b>`) are left untouched.
+
+| Option              | Description                                                          |
+| -------------------- | ---------------------------------------------------------------------- |
+| `--sourceLocale`     | Source locale to read. Default `en`.                                  |
+| `--outputLocale`     | Locale code the output table is written under. Default `qps-ploc`.    |
+| `--expansionFactor`  | Length multiplier applied to each string. Default `1.3`.              |
+| `--outputPath`       | Directory to write the output table into. Defaults to `projectPath`.  |

--- a/docs/03-github-cli/06-experimental-plugins.mdx
+++ b/docs/03-github-cli/06-experimental-plugins.mdx
@@ -24,15 +24,15 @@ directory - every top-level file inside it is uploaded as a separate asset, name
 Re-running against the same tag is idempotent: an existing release for that tag is reused, and an
 asset that already exists on it is replaced rather than failing.
 
-| Option              | Description                                                         |
-| -------------------- | -------------------------------------------------------------------- |
-| `--repo`             | `owner/repo`. Defaults to `$GITHUB_REPOSITORY`.                     |
-| `--tag`              | Release tag. Required.                                              |
-| `--releaseNotes`     | Release body/description.                                           |
-| `--draft`            | Create the release as a draft.                                      |
-| `--prerelease`       | Mark the release as a prerelease.                                   |
-| `--assetName`        | Override the uploaded asset's file name (single-file buildPath only). |
-| `--targetCommitish`  | Commit/branch to create the tag from, if it doesn't already exist.  |
+| Option              | Description                                                           |
+| ------------------- | --------------------------------------------------------------------- |
+| `--repo`            | `owner/repo`. Defaults to `$GITHUB_REPOSITORY`.                       |
+| `--tag`             | Release tag. Required.                                                |
+| `--releaseNotes`    | Release body/description.                                             |
+| `--draft`           | Create the release as a draft.                                        |
+| `--prerelease`      | Mark the release as a prerelease.                                     |
+| `--assetName`       | Override the uploaded asset's file name (single-file buildPath only). |
+| `--targetCommitish` | Commit/branch to create the tag from, if it doesn't already exist.    |
 
 GitLab Release support isn't included in this first version.
 
@@ -49,14 +49,14 @@ BUTLER_API_KEY=... game-ci \
 Requires `butler` already installed and on `PATH` (or pass `--butlerPath` explicitly - recommended
 for CI determinism). This plugin doesn't install butler for you.
 
-| Option          | Description                                                                 |
-| ----------------- | ---------------------------------------------------------------------------- |
-| `--user`         | itch.io username or organization. Required.                                 |
-| `--game`         | itch.io game slug. Required.                                                |
-| `--channel`      | Channel to push to, e.g. `windows`, `linux`, `web`. Required.               |
-| `--butlerPath`   | Explicit path to the butler executable.                                     |
-| `--userVersion`  | Custom version string shown in itch.io's build history.                     |
-| `--ignore`       | Comma-separated glob patterns excluded from the push.                       |
+| Option          | Description                                                   |
+| --------------- | ------------------------------------------------------------- |
+| `--user`        | itch.io username or organization. Required.                   |
+| `--game`        | itch.io game slug. Required.                                  |
+| `--channel`     | Channel to push to, e.g. `windows`, `linux`, `web`. Required. |
+| `--butlerPath`  | Explicit path to the butler executable.                       |
+| `--userVersion` | Custom version string shown in itch.io's build history.       |
+| `--ignore`      | Comma-separated glob patterns excluded from the push.         |
 
 ## Pseudo-localization QA
 
@@ -78,8 +78,8 @@ the pipeline stands out), length expansion (`--expansionFactor`, default `1.3` -
 Format placeholders (`{0}`, `%s`) and simple markup (`<b>...</b>`) are left untouched.
 
 | Option              | Description                                                          |
-| -------------------- | ---------------------------------------------------------------------- |
-| `--sourceLocale`     | Source locale to read. Default `en`.                                  |
-| `--outputLocale`     | Locale code the output table is written under. Default `qps-ploc`.    |
-| `--expansionFactor`  | Length multiplier applied to each string. Default `1.3`.              |
-| `--outputPath`       | Directory to write the output table into. Defaults to `projectPath`.  |
+| ------------------- | -------------------------------------------------------------------- |
+| `--sourceLocale`    | Source locale to read. Default `en`.                                 |
+| `--outputLocale`    | Locale code the output table is written under. Default `qps-ploc`.   |
+| `--expansionFactor` | Length multiplier applied to each string. Default `1.3`.             |
+| `--outputPath`      | Directory to write the output table into. Defaults to `projectPath`. |


### PR DESCRIPTION
## Summary
Documents \`@game-ci/github-release-deploy\`, \`@game-ci/itch-deploy\`, and \`@game-ci/pseudo-localization\` now that they're real implementations rather than structural drafts:

- game-ci/cli#217 - github-release-deploy
- game-ci/cli#219 - itch-deploy
- game-ci/cli#218 - pseudo-localization

All three were previously entirely undocumented anywhere (their commands threw immediately, so there was nothing to document). New page under CLI docs, following the existing configuration-and-plugins page's structure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added documentation for three experimental CLI plugins.
  * Included setup instructions, usage examples, available options, and limitations.
  * Documented GitHub Release deployment, itch.io uploads, and pseudo-localization workflows.
  * Clarified opt-in usage, required tooling, rerun behavior, and unsupported localization formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->