### PR TITLE
Add job timeouts and split cache save/restore in CI workflows

### DIFF
--- a/.github/workflows/cats.yml
+++ b/.github/workflows/cats.yml
@@ -10,6 +10,7 @@ jobs:
   aCatForCreatingThePullRequest:
     name: A cat for your effort!
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Action Cats
         uses: ruairidhwm/action-cats@1.0.2

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -8,6 +8,7 @@ jobs:
   codeFormatting:
     name: Code formatting
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - name: Read Node version from mise.toml
@@ -25,7 +26,7 @@ jobs:
         id: yarn-config
         run: echo "cacheFolder=$(yarn config get cacheFolder)" >> "$GITHUB_OUTPUT"
       - name: Restore yarn install cache (node_modules + cacheFolder + install-state)
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: |
             node_modules
@@ -42,10 +43,24 @@ jobs:
         run: |
           case "$(yarn --version)" in 1.*) echo 'expected up-to-date yarn version'; exit 1 ;; esac
           yarn install --immutable
+      - name: Save yarn install cache (node_modules + cacheFolder + install-state)
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            node_modules
+            ${{ steps.yarn-config.outputs.cacheFolder }}
+            .yarn/install-state.gz
+          key:
+            yarn-${{ runner.os }}-node${{ steps.node.outputs.version }}-${{ hashFiles('yarn.lock')
+            }}
+        timeout-minutes: 5
+        continue-on-error: true
       - run: yarn format:check
   codeStyles:
     name: Code styles
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - name: Read Node version from mise.toml
@@ -63,7 +78,7 @@ jobs:
         id: yarn-config
         run: echo "cacheFolder=$(yarn config get cacheFolder)" >> "$GITHUB_OUTPUT"
       - name: Restore yarn install cache (node_modules + cacheFolder + install-state)
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: |
             node_modules
@@ -80,10 +95,24 @@ jobs:
         run: |
           case "$(yarn --version)" in 1.*) echo 'expected up-to-date yarn version'; exit 1 ;; esac
           yarn install --immutable
+      - name: Save yarn install cache (node_modules + cacheFolder + install-state)
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            node_modules
+            ${{ steps.yarn-config.outputs.cacheFolder }}
+            .yarn/install-state.gz
+          key:
+            yarn-${{ runner.os }}-node${{ steps.node.outputs.version }}-${{ hashFiles('yarn.lock')
+            }}
+        timeout-minutes: 5
+        continue-on-error: true
       - run: yarn lint
   types:
     name: Types check
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - name: Read Node version from mise.toml
@@ -101,7 +130,7 @@ jobs:
         id: yarn-config
         run: echo "cacheFolder=$(yarn config get cacheFolder)" >> "$GITHUB_OUTPUT"
       - name: Restore yarn install cache (node_modules + cacheFolder + install-state)
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: |
             node_modules
@@ -118,10 +147,24 @@ jobs:
         run: |
           case "$(yarn --version)" in 1.*) echo 'expected up-to-date yarn version'; exit 1 ;; esac
           yarn install --immutable
+      - name: Save yarn install cache (node_modules + cacheFolder + install-state)
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            node_modules
+            ${{ steps.yarn-config.outputs.cacheFolder }}
+            .yarn/install-state.gz
+          key:
+            yarn-${{ runner.os }}-node${{ steps.node.outputs.version }}-${{ hashFiles('yarn.lock')
+            }}
+        timeout-minutes: 5
+        continue-on-error: true
       - run: yarn typecheck
   tests:
     name: Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - name: Read Node version from mise.toml
@@ -139,7 +182,7 @@ jobs:
         id: yarn-config
         run: echo "cacheFolder=$(yarn config get cacheFolder)" >> "$GITHUB_OUTPUT"
       - name: Restore yarn install cache (node_modules + cacheFolder + install-state)
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: |
             node_modules
@@ -156,6 +199,19 @@ jobs:
         run: |
           case "$(yarn --version)" in 1.*) echo 'expected up-to-date yarn version'; exit 1 ;; esac
           yarn install --immutable
+      - name: Save yarn install cache (node_modules + cacheFolder + install-state)
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            node_modules
+            ${{ steps.yarn-config.outputs.cacheFolder }}
+            .yarn/install-state.gz
+          key:
+            yarn-${{ runner.os }}-node${{ steps.node.outputs.version }}-${{ hashFiles('yarn.lock')
+            }}
+        timeout-minutes: 5
+        continue-on-error: true
       - run: yarn test --coverage
       - run: bash <(curl -s https://codecov.io/bash)
         env:
@@ -163,6 +219,7 @@ jobs:
   e2e:
     name: E2E tests
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - name: Read Node version from mise.toml
@@ -180,7 +237,7 @@ jobs:
         id: yarn-config
         run: echo "cacheFolder=$(yarn config get cacheFolder)" >> "$GITHUB_OUTPUT"
       - name: Restore yarn install cache (node_modules + cacheFolder + install-state)
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: |
             node_modules
@@ -197,6 +254,19 @@ jobs:
         run: |
           case "$(yarn --version)" in 1.*) echo 'expected up-to-date yarn version'; exit 1 ;; esac
           yarn install --immutable
+      - name: Save yarn install cache (node_modules + cacheFolder + install-state)
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            node_modules
+            ${{ steps.yarn-config.outputs.cacheFolder }}
+            .yarn/install-state.gz
+          key:
+            yarn-${{ runner.os }}-node${{ steps.node.outputs.version }}-${{ hashFiles('yarn.lock')
+            }}
+        timeout-minutes: 5
+        continue-on-error: true
       - run: yarn build
       - run: npx playwright install --with-deps chromium
       - run: yarn test:e2e

--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -9,6 +9,7 @@ name: Deploy Live
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       # Checkout
       - uses: actions/checkout@v4
@@ -29,7 +30,7 @@ jobs:
         id: yarn-config
         run: echo "cacheFolder=$(yarn config get cacheFolder)" >> "$GITHUB_OUTPUT"
       - name: Restore yarn install cache (node_modules + cacheFolder + install-state)
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: |
             node_modules
@@ -46,6 +47,19 @@ jobs:
         run: |
           case "$(yarn --version)" in 1.*) echo 'expected up-to-date yarn version'; exit 1 ;; esac
           yarn install --immutable
+      - name: Save yarn install cache (node_modules + cacheFolder + install-state)
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            node_modules
+            ${{ steps.yarn-config.outputs.cacheFolder }}
+            .yarn/install-state.gz
+          key:
+            yarn-${{ runner.os }}-node${{ steps.node.outputs.version }}-${{ hashFiles('yarn.lock')
+            }}
+        timeout-minutes: 5
+        continue-on-error: true
       - name: Build website
         run: yarn build
 

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -7,6 +7,7 @@ jobs:
   build_and_preview:
     if: '${{ github.event.pull_request.head.repo.full_name == github.repository }}'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       # Checkout
       - uses: actions/checkout@v4
@@ -27,7 +28,7 @@ jobs:
         id: yarn-config
         run: echo "cacheFolder=$(yarn config get cacheFolder)" >> "$GITHUB_OUTPUT"
       - name: Restore yarn install cache (node_modules + cacheFolder + install-state)
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: |
             node_modules
@@ -44,6 +45,19 @@ jobs:
         run: |
           case "$(yarn --version)" in 1.*) echo 'expected up-to-date yarn version'; exit 1 ;; esac
           yarn install --immutable
+      - name: Save yarn install cache (node_modules + cacheFolder + install-state)
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            node_modules
+            ${{ steps.yarn-config.outputs.cacheFolder }}
+            .yarn/install-state.gz
+          key:
+            yarn-${{ runner.os }}-node${{ steps.node.outputs.version }}-${{ hashFiles('yarn.lock')
+            }}
+        timeout-minutes: 5
+        continue-on-error: true
       - name: Build website
         run: yarn build
 

--- a/.github/workflows/search-trigger.yml
+++ b/.github/workflows/search-trigger.yml
@@ -5,6 +5,7 @@ jobs:
   updateSearchIndex:
     name: Update search index
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: darrenjennings/algolia-docsearch-action@da2ed379c147b356d60dbfec68bdcfacb2791a98


### PR DESCRIPTION
## Summary
- Add `timeout-minutes` to every job in `checks.yml`, `firebase-hosting-merge.yml`, `firebase-hosting-pull-request.yml`, `cats.yml`, and `search-trigger.yml` so a genuinely hung job fails fast instead of blocking the runner/queue indefinitely.
- Split all `actions/cache@v4` usages in `checks.yml` and both firebase-hosting workflows into the explicit `restore` + `save` pattern (save moved to end of job, `if: always()`, `continue-on-error: true`, own `timeout-minutes: 5`) to avoid the known post-run cache-save hang. `path`/`key`/`restore-keys` left unchanged.

## Jobs touched and timeout values chosen
- `checks.yml`
  - `codeFormatting` (yarn format:check) — 10m
  - `codeStyles` (yarn lint) — 10m
  - `types` (yarn typecheck) — 10m
  - `tests` (yarn test --coverage + codecov upload) — 15m
  - `e2e` (yarn build + playwright install + e2e tests) — 20m
- `firebase-hosting-merge.yml`: `build_and_deploy` (build + Firebase live deploy) — 20m
- `firebase-hosting-pull-request.yml`: `build_and_preview` (build + Firebase preview deploy) — 20m
- `cats.yml`: `aCatForCreatingThePullRequest` (single third-party action call) — 5m
- `search-trigger.yml`: `updateSearchIndex` (Algolia docsearch crawl trigger) — 10m

## Validation
- `actionlint` (installed globally) run against all 5 edited workflow files — no errors.
- All 5 files also parsed successfully with Python `yaml.safe_load`.

## Test plan
- [ ] Confirm workflows still trigger and pass normally on this branch's own checks/PR run
- [ ] Confirm cache restore/save steps still populate and hit cache on subsequent runs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI/CD Improvements**
  * Added execution time limits across automated validation, deployment, pull request, and search-index workflows.
  * Improved dependency caching to restore and save caches independently.
  * Ensured cache-saving steps run even when earlier steps fail, while allowing cache errors without blocking workflows.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->