### PR TITLE
docs: document build memory limits and container env var behaviour

### DIFF
--- a/docs/03-github/04-builder.mdx
+++ b/docs/03-github/04-builder.mdx
@@ -560,14 +560,14 @@ line.
 
 Docker-based builds do not inherit the workflow environment — GameCI forwards a fixed set of
 variables into the container, so a variable set in the job's `env:` block is otherwise dropped at
-the container boundary. Use this for anything inside the build that reads the environment directly,
-such as Unity's own `IL2CPP_ADDITIONAL_ARGS`:
+the container boundary. Use this for anything inside the build that reads the environment directly:
 
 ```yaml
 - uses: game-ci/unity-builder@v6
   env:
     GAME_CI_DOCKER_ENV: |
-      IL2CPP_ADDITIONAL_ARGS=--maxcpucount=2
+      MY_CUSTOM_FLAG=someValue
+      BUILD_CHANNEL=nightly
 ```
 
 Names GameCI sets itself (`UNITY_LICENSE`, `PROJECT_PATH`, `BUILD_TARGET`, and similar) are

--- a/docs/03-github/04-builder.mdx
+++ b/docs/03-github/04-builder.mdx
@@ -578,6 +578,44 @@ To pass a Unity editor command line argument instead, use
 
 _**required:** `false`_ _**default:** `""`_
 
+#### unitySettings
+
+Unity Editor, Project and Player settings to apply at build time, one directive per line.
+
+Some Unity settings exist only as an Editor scripting API — no command line argument and no
+environment variable — with asset import worker counts the common example. This applies those APIs
+for you, instead of requiring a hand-written build method:
+
+```yaml
+- uses: game-ci/unity-builder@v6
+  env:
+    GAME_CI_UNITY_SETTINGS: |
+      EditorUserSettings.desiredImportWorkerCount = 4
+      PlayerSettings.SetIl2CppCodeGeneration(Standalone, OptimizeSize)
+```
+
+Two forms are supported: assignment (`Type.Member = value`) for properties and fields, and
+invocation (`Type.Method(a, b)`) for setter methods. Directives are applied by reflection against
+Unity's editor assemblies, so any static settings API Unity exposes is reachable. Settings are
+applied to the CI checkout only — your committed Project Settings are unchanged.
+
+Unrecognised directives warn rather than fail; see
+[`unitySettingsStrict`](#unitysettingsstrict). Full details in
+[setting any Unity Editor or Project setting](/docs/troubleshooting/common-issues#setting-any-unity-editor-or-project-setting).
+
+_**required:** `false`_ _**default:** `""`_
+
+#### unitySettingsStrict
+
+Fail the build if any [`unitySettings`](#unitysettings) directive cannot be applied, instead of
+warning and continuing.
+
+The default is lenient so that a setting which exists in one Unity version but not another does not
+break an otherwise valid build — relevant when building a matrix of Unity versions. Set this when
+building with the wrong settings would be worse than not building at all.
+
+_**required:** `false`_ _**default:** `false`_
+
 #### dockerIsolationMode
 
 Isolation mode to use for the Docker container when running on Windows. Can be one of:

--- a/docs/03-github/04-builder.mdx
+++ b/docs/03-github/04-builder.mdx
@@ -535,6 +535,18 @@ defaults to 75% of total system memory. To manually specify a value, use the for
 
 _**required:** `false`_ _**default:** `""`_
 
+#### dockerShmSize
+
+Size of `/dev/shm` (shared memory) to assign to the Docker container, using the format
+\<number\>\<unit\> where the unit is `m` or `g`.
+
+Unity 6.6 and newer request 1 GiB of shared memory and fail with
+`Insufficient shared memory available` against Docker's much smaller default, so GameCI passes
+`1025m` unless you specify otherwise. Pass a larger value if you see that error, or `0` to omit the
+flag entirely and use Docker's own default.
+
+_**required:** `false`_ _**default:** `"1025m"`_
+
 #### dockerIsolationMode
 
 Isolation mode to use for the Docker container when running on Windows. Can be one of:

--- a/docs/03-github/04-builder.mdx
+++ b/docs/03-github/04-builder.mdx
@@ -131,6 +131,12 @@ This simple addition could speed up your build by more than 50%.
 
 Below options can be specified under `with:` for the `unity-builder` action.
 
+Every option can also be set with an environment variable, by upper-snake-casing its name and
+prefixing it with `GAME_CI_` — `dockerMemoryLimit` becomes `GAME_CI_DOCKER_MEMORY_LIMIT`. An option
+you set under `with:` always takes precedence over the matching environment variable, so
+`GAME_CI_*` only fills in what you left unset. See
+[setting any option with an environment variable](/docs/troubleshooting/common-issues#setting-any-option-with-an-environment-variable).
+
 #### targetPlatform
 
 Platform that the build should target.
@@ -546,6 +552,31 @@ Unity 6.6 and newer request 1 GiB of shared memory and fail with
 flag entirely and use Docker's own default.
 
 _**required:** `false`_ _**default:** `"1025m"`_
+
+#### dockerEnv
+
+Additional environment variables to set inside the Docker container, one `NAME=value` pair per
+line.
+
+Docker-based builds do not inherit the workflow environment — GameCI forwards a fixed set of
+variables into the container, so a variable set in the job's `env:` block is otherwise dropped at
+the container boundary. Use this for anything inside the build that reads the environment directly,
+such as Unity's own `IL2CPP_ADDITIONAL_ARGS`:
+
+```yaml
+- uses: game-ci/unity-builder@v6
+  env:
+    GAME_CI_DOCKER_ENV: |
+      IL2CPP_ADDITIONAL_ARGS=--maxcpucount=2
+```
+
+Names GameCI sets itself (`UNITY_LICENSE`, `PROJECT_PATH`, `BUILD_TARGET`, and similar) are
+reserved; attempting to overwrite one produces a warning naming the collision.
+
+To pass a Unity editor command line argument instead, use
+[`customParameters`](#customparameters).
+
+_**required:** `false`_ _**default:** `""`_
 
 #### dockerIsolationMode
 

--- a/docs/09-troubleshooting/common-issues.mdx
+++ b/docs/09-troubleshooting/common-issues.mdx
@@ -373,17 +373,11 @@ this again, since each project imports its own assets.
        dockerMemoryLimit: 15500m
    ```
 
-2. **Reduce parallelism.** Fewer concurrent workers means a lower peak, at the cost of some wall
-   time. Unity's editor command line accepts arguments for this, which you can pass through
-   [`customParameters`](/docs/github/builder#customparameters):
-
-   ```yaml
-   with:
-     customParameters: -maxConcurrentImport 2
-   ```
-
-   Settings appropriate for a developer's workstation are frequently too aggressive for a CI
-   runner — it is normal and expected for these to differ between the two.
+2. **Reduce worker parallelism.** Fewer concurrent import and IL2CPP workers means a lower peak, at
+   the cost of some wall time. Settings appropriate for a developer's workstation are frequently too
+   aggressive for a CI runner — it is normal and expected for these to differ between the two. See
+   [Controlling import and IL2CPP worker parallelism](#controlling-import-and-il2cpp-worker-parallelism)
+   below for a worked example.
 
 3. **Reduce what IL2CPP has to do.** In Player Settings, setting **IL2CPP Code Generation** to
    _Faster (smaller) builds_ (`Il2CppCodeGeneration.OptimizeSize`) meaningfully lowers both memory
@@ -394,15 +388,104 @@ this again, since each project imports its own assets.
    controls this.
 
 5. **Apply CI-only settings without changing your local project.** Project Settings are committed to
-   the repository, so changing them affects local development too. To avoid that, set them from an
-   editor script at build time and gate it behind a flag passed via `customParameters`, read with
-   `Environment.GetCommandLineArgs()`. Point GameCI at that script with
-   [`buildMethod`](/docs/github/builder#buildmethod).
+   the repository, so changing them affects local development too. The worked example below applies
+   them at build time instead, so your local workflow is untouched.
 
 6. **Use a larger runner.** If peak memory genuinely exceeds the runner's capacity, use
    [GitHub-Hosted Larger Runners](https://docs.github.com/en/actions/how-tos/manage-runners/larger-runners),
    a [self-hosted runner](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners),
    or [Orchestrator](/docs/github-orchestrator/introduction-to-orchestrator/game-ci-vs-orchestrator).
+
+#### Controlling import and IL2CPP worker parallelism
+
+Worker counts are the most effective dial for peak memory, but there is an important constraint on
+_how_ you set them: because
+[environment variables are not forwarded into the container](#environment-variables-set-in-my-workflow-dont-reach-unity),
+`IL2CPP_ADDITIONAL_ARGS` cannot be used to pass IL2CPP arguments. Set them from an editor script
+instead.
+
+The pattern is to inject a worker count through
+[`customParameters`](/docs/github/builder#customparameters), then read it in a build method pointed
+at by [`buildMethod`](/docs/github/builder#buildmethod). This keeps the setting CI-only, so your
+committed Project Settings — and everyone's local builds — stay unchanged.
+
+```yaml
+- name: Build Unity Project
+  uses: game-ci/unity-builder@v6
+  env:
+    UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+    UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+    UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+  with:
+    targetPlatform: StandaloneWindows64
+    dockerMemoryLimit: 15500m
+    buildMethod: CI.CiBuild.Build
+    customParameters: -ciWorkers 2
+```
+
+```csharp
+// Assets/Editor/CiBuild.cs
+using System;
+using System.Linq;
+using UnityEditor;
+using UnityEditor.Build;
+using UnityEditor.Build.Reporting;
+
+namespace CI
+{
+    public static class CiBuild
+    {
+        public static void Build()
+        {
+            var workers = GetIntArg("-ciWorkers", 2);
+
+            // Asset import workers (Project Settings > Editor > Asset Pipeline).
+            EditorSettings.desiredImportWorkerCount = workers;
+            EditorSettings.standbyImportWorkerCount = Math.Min(workers, 2);
+
+            // IL2CPP compile parallelism. IL2CPP_ADDITIONAL_ARGS is unavailable here,
+            // because environment variables do not reach inside the container.
+            PlayerSettings.SetAdditionalIl2CppArgs($"--maxcpucount={workers}");
+
+            // Lowers peak memory considerably on large codebases.
+            PlayerSettings.SetIl2CppCodeGeneration(
+                NamedBuildTarget.Standalone, Il2CppCodeGeneration.OptimizeSize);
+
+            var report = BuildPipeline.BuildPlayer(new BuildPlayerOptions
+            {
+                scenes = EditorBuildSettings.scenes
+                    .Where(scene => scene.enabled)
+                    .Select(scene => scene.path)
+                    .ToArray(),
+                locationPathName = "build/StandaloneWindows64/game.exe",
+                target = BuildTarget.StandaloneWindows64,
+            });
+
+            EditorApplication.Exit(report.summary.result == BuildResult.Succeeded ? 0 : 1);
+        }
+
+        static int GetIntArg(string name, int fallback)
+        {
+            var args = Environment.GetCommandLineArgs();
+            var index = Array.IndexOf(args, name);
+
+            return index >= 0 && index + 1 < args.Length && int.TryParse(args[index + 1], out var value)
+                ? value
+                : fallback;
+        }
+    }
+}
+```
+
+:::note
+
+The `customParameters` and `buildMethod` plumbing shown here is stable: `customParameters` is passed
+through to Unity's command line and is readable via `Environment.GetCommandLineArgs()`, and
+`buildMethod` becomes Unity's `-executeMethod`. The specific `EditorSettings` and `PlayerSettings`
+API names, however, have changed across Unity versions — check them against the scripting reference
+for the version you build with, and adjust as needed.
+
+:::
 
 ### Environment variables set in my workflow don't reach Unity
 

--- a/docs/09-troubleshooting/common-issues.mdx
+++ b/docs/09-troubleshooting/common-issues.mdx
@@ -391,7 +391,15 @@ this again, since each project imports its own assets.
    the repository, so changing them affects local development too. The worked example below applies
    them at build time instead, so your local workflow is untouched.
 
-6. **Use a larger runner.** If peak memory genuinely exceeds the runner's capacity, use
+6. **Be careful with `IL2CPP_ADDITIONAL_ARGS`.** It is often suggested for this, but Unity passes
+   its contents
+   [straight to the C++ compiler](https://docs.unity3d.com/6000.0/Documentation/ScriptReference/PlayerSettings.SetAdditionalIl2CppArgs.html)
+   with no interpretation — "valid compiler flags depend on the platform you are building for and
+   the C++ compiler used by IL2CPP on that platform". So it takes clang or MSVC flags, not
+   build-orchestration flags, and Unity documents no accepted list and marks the feature
+   experimental. Prefer the options above, which are documented and platform-independent.
+
+7. **Use a larger runner.** If peak memory genuinely exceeds the runner's capacity, use
    [GitHub-Hosted Larger Runners](https://docs.github.com/en/actions/how-tos/manage-runners/larger-runners),
    a [self-hosted runner](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners),
    or [Orchestrator](/docs/github-orchestrator/introduction-to-orchestrator/game-ci-vs-orchestrator).
@@ -415,10 +423,9 @@ None of these require you to write an editor script:
 ```yaml
 - uses: game-ci/unity-builder@v6
   env:
-    GAME_CI_DOCKER_ENV: |
-      IL2CPP_ADDITIONAL_ARGS=--maxcpucount=2
     GAME_CI_UNITY_SETTINGS: |
       EditorUserSettings.desiredImportWorkerCount = 2
+      PlayerSettings.SetIl2CppCodeGeneration(Standalone, OptimizeSize)
   with:
     customParameters: -job-worker-count 2
 ```
@@ -470,11 +477,6 @@ namespace CI
             // command line or environment equivalent - hence the editor script.
             EditorUserSettings.desiredImportWorkerCount = workers;
             EditorUserSettings.standbyImportWorkerCount = Math.Min(workers, 2);
-
-            // IL2CPP compile parallelism. Equivalent to setting
-            // IL2CPP_ADDITIONAL_ARGS via dockerEnv - use whichever you prefer,
-            // not both.
-            PlayerSettings.SetAdditionalIl2CppArgs($"--maxcpucount={workers}");
 
             // Lowers peak memory considerably on large codebases.
             PlayerSettings.SetIl2CppCodeGeneration(
@@ -549,14 +551,14 @@ variables are set inside the container where Unity can read them normally:
 - uses: game-ci/unity-builder@v6
   env:
     GAME_CI_DOCKER_ENV: |
-      IL2CPP_ADDITIONAL_ARGS=--maxcpucount=2
       MY_CUSTOM_FLAG=someValue
+      BUILD_CHANNEL=nightly
 ```
 
 Read them in an editor script the usual way:
 
 ```csharp
-var args = Environment.GetEnvironmentVariable("IL2CPP_ADDITIONAL_ARGS");
+var channel = Environment.GetEnvironmentVariable("BUILD_CHANNEL");
 ```
 
 Alternatively, pass the value as a Unity editor command line argument via
@@ -597,7 +599,6 @@ setting:
       EditorUserSettings.standbyImportWorkerCount = 2
       EditorSettings.refreshImportMode = OutOfProcessPerQueue
       PlayerSettings.SetIl2CppCodeGeneration(Standalone, OptimizeSize)
-      PlayerSettings.SetAdditionalIl2CppArgs("--maxcpucount=2")
 ```
 
 Each line is one directive, in one of two forms:
@@ -668,8 +669,8 @@ CLI option, including ones the action has no matching input for:
   env:
     GAME_CI_DOCKER_MEMORY_LIMIT: 14g
     GAME_CI_DOCKER_SHM_SIZE: 2g
-    GAME_CI_DOCKER_ENV: |
-      IL2CPP_ADDITIONAL_ARGS=--maxcpucount=2
+    GAME_CI_UNITY_SETTINGS: |
+      EditorUserSettings.desiredImportWorkerCount = 2
 ```
 
 Precedence is **explicit input wins over environment variable, which wins over the default**. So an

--- a/docs/09-troubleshooting/common-issues.mdx
+++ b/docs/09-troubleshooting/common-issues.mdx
@@ -398,13 +398,36 @@ this again, since each project imports its own assets.
 
 #### Controlling import and IL2CPP worker parallelism
 
-Worker counts are the most effective dial for peak memory, but there is an important constraint on
-_how_ you set them: because
-[environment variables are not forwarded into the container](#environment-variables-set-in-my-workflow-dont-reach-unity),
-`IL2CPP_ADDITIONAL_ARGS` cannot be used to pass IL2CPP arguments. Set them from an editor script
-instead.
+Worker counts are the most effective dial for peak memory. Which mechanism you use depends on how
+Unity exposes the particular setting — there are three, and not every setting is reachable by all
+of them:
 
-The pattern is to inject a worker count through
+| Setting                                           | How Unity exposes it | How to set it in CI                                                 |
+| ------------------------------------------------- | -------------------- | ------------------------------------------------------------------- |
+| IL2CPP compiler args (`IL2CPP_ADDITIONAL_ARGS`)   | Environment variable | [`dockerEnv`](/docs/github/builder#dockerenv)                       |
+| Job worker threads (`-job-worker-count`)          | Editor command line  | [`customParameters`](/docs/github/builder#customparameters)         |
+| GC helper threads (`-gc-helper-count`)            | Editor command line  | [`customParameters`](/docs/github/builder#customparameters)         |
+| Asset import workers (`desiredImportWorkerCount`) | Editor API only      | Editor script via [`buildMethod`](/docs/github/builder#buildmethod) |
+| IL2CPP code generation, Burst settings            | Editor API only      | Editor script via [`buildMethod`](/docs/github/builder#buildmethod) |
+
+The first two rows need no editor script at all:
+
+```yaml
+- uses: game-ci/unity-builder@v6
+  env:
+    GAME_CI_DOCKER_ENV: |
+      IL2CPP_ADDITIONAL_ARGS=--maxcpucount=2
+  with:
+    customParameters: -job-worker-count 2
+```
+
+Asset import workers are the exception worth knowing about: Unity exposes **no command line
+argument and no environment variable** for them, only the
+[`EditorUserSettings.desiredImportWorkerCount`](https://docs.unity3d.com/6000.0/Documentation/ScriptReference/EditorUserSettings-desiredImportWorkerCount.html)
+scripting API. Setting those requires an editor script — that is a Unity constraint, not a GameCI
+one.
+
+The pattern for the editor-script cases is to inject a worker count through
 [`customParameters`](/docs/github/builder#customparameters), then read it in a build method pointed
 at by [`buildMethod`](/docs/github/builder#buildmethod). This keeps the setting CI-only, so your
 committed Project Settings — and everyone's local builds — stay unchanged.
@@ -440,11 +463,14 @@ namespace CI
             var workers = GetIntArg("-ciWorkers", 2);
 
             // Asset import workers (Project Settings > Editor > Asset Pipeline).
-            EditorSettings.desiredImportWorkerCount = workers;
-            EditorSettings.standbyImportWorkerCount = Math.Min(workers, 2);
+            // These live on EditorUserSettings, not EditorSettings, and have no
+            // command line or environment equivalent - hence the editor script.
+            EditorUserSettings.desiredImportWorkerCount = workers;
+            EditorUserSettings.standbyImportWorkerCount = Math.Min(workers, 2);
 
-            // IL2CPP compile parallelism. IL2CPP_ADDITIONAL_ARGS is unavailable here,
-            // because environment variables do not reach inside the container.
+            // IL2CPP compile parallelism. Equivalent to setting
+            // IL2CPP_ADDITIONAL_ARGS via dockerEnv - use whichever you prefer,
+            // not both.
             PlayerSettings.SetAdditionalIl2CppArgs($"--maxcpucount={workers}");
 
             // Lowers peak memory considerably on large codebases.
@@ -481,9 +507,10 @@ namespace CI
 
 The `customParameters` and `buildMethod` plumbing shown here is stable: `customParameters` is passed
 through to Unity's command line and is readable via `Environment.GetCommandLineArgs()`, and
-`buildMethod` becomes Unity's `-executeMethod`. The specific `EditorSettings` and `PlayerSettings`
-API names, however, have changed across Unity versions — check them against the scripting reference
-for the version you build with, and adjust as needed.
+`buildMethod` becomes Unity's `-executeMethod`. The `EditorUserSettings` and `PlayerSettings` API
+names, however, have moved between classes and versions — check them against the scripting
+reference for the version you build with, and adjust as needed. Note that
+`SetAdditionalIl2CppArgs` is documented by Unity as experimental.
 
 :::
 

--- a/docs/09-troubleshooting/common-issues.mdx
+++ b/docs/09-troubleshooting/common-issues.mdx
@@ -322,6 +322,133 @@ collectively consume a significant amount of disk space.
    [Orchestrator](/docs/github-orchestrator/introduction-to-orchestrator/game-ci-vs-orchestrator).
    This would give you more control over the resources and disk space.
 
+### Build runs out of memory (IL2CPP, Burst, or LLVM)
+
+#### Error
+
+Typically surfaces during IL2CPP compilation or Burst AOT compilation, often as an LLVM failure,
+a killed process, or a build that dies without a clear Unity error:
+
+```plaintext
+LLVM ERROR: out of memory
+```
+
+```plaintext
+Fatal error in Unity CIL Linker
+Burst compiler failed running
+```
+
+#### Explanation
+
+There are two separate memory ceilings involved, and it's worth knowing which one you've hit.
+
+**1. The container's memory limit.** GameCI assigns the Docker container a memory limit derived from
+the host's total memory. It does not hand the container everything the machine has:
+
+- **Linux:** 95% of total system memory
+- **Windows:** 80% of total system memory
+- **Other platforms:** 75% of total system memory
+
+On a standard GitHub-hosted runner (16 GB), a Windows build therefore gets roughly 12.8 GB, leaving
+about 3 GB unused. Raising [`dockerMemoryLimit`](/docs/github/builder#dockermemorylimit) reclaims
+that headroom.
+
+**2. The machine's actual memory.** If the build needs more than the runner physically has, no limit
+setting will help — you need a bigger machine or a smaller peak.
+
+Peak memory is driven heavily by _parallelism_. IL2CPP, Burst, and the asset importer all run
+concurrent workers by default, and each worker holds its own working set. Projects using DOTS/ECS
+with heavy Burst compilation are especially affected, because Burst AOT compiles a large amount of
+generated code at build time. Checking out more than one Unity project in the same job multiplies
+this again, since each project imports its own assets.
+
+#### Solution
+
+1. **Raise the container memory limit.** Especially worthwhile on Windows, where 20% of the runner's
+   memory is unused by default:
+
+   ```yaml
+   - uses: game-ci/unity-builder@v6
+     with:
+       dockerMemoryLimit: 15500m
+   ```
+
+2. **Reduce parallelism.** Fewer concurrent workers means a lower peak, at the cost of some wall
+   time. Unity's editor command line accepts arguments for this, which you can pass through
+   [`customParameters`](/docs/github/builder#customparameters):
+
+   ```yaml
+   with:
+     customParameters: -maxConcurrentImport 2
+   ```
+
+   Settings appropriate for a developer's workstation are frequently too aggressive for a CI
+   runner — it is normal and expected for these to differ between the two.
+
+3. **Reduce what IL2CPP has to do.** In Player Settings, setting **IL2CPP Code Generation** to
+   _Faster (smaller) builds_ (`Il2CppCodeGeneration.OptimizeSize`) meaningfully lowers both memory
+   use and build time on large codebases.
+
+4. **Review Burst AOT Settings.** For DOTS/ECS projects, Burst compilation during the build is
+   often the real memory consumer rather than IL2CPP itself. Project Settings → Burst AOT Settings
+   controls this.
+
+5. **Apply CI-only settings without changing your local project.** Project Settings are committed to
+   the repository, so changing them affects local development too. To avoid that, set them from an
+   editor script at build time and gate it behind a flag passed via `customParameters`, read with
+   `Environment.GetCommandLineArgs()`. Point GameCI at that script with
+   [`buildMethod`](/docs/github/builder#buildmethod).
+
+6. **Use a larger runner.** If peak memory genuinely exceeds the runner's capacity, use
+   [GitHub-Hosted Larger Runners](https://docs.github.com/en/actions/how-tos/manage-runners/larger-runners),
+   a [self-hosted runner](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners),
+   or [Orchestrator](/docs/github-orchestrator/introduction-to-orchestrator/game-ci-vs-orchestrator).
+
+### Environment variables set in my workflow don't reach Unity
+
+#### Error
+
+An environment variable set in the workflow appears to be ignored inside the build — for example
+setting `IL2CPP_ADDITIONAL_ARGS` in `env:` has no effect on the build at all.
+
+#### Explanation
+
+Docker-based builds run Unity inside a container, and the container does not inherit the workflow's
+environment. GameCI forwards a specific, fixed set of variables into it, not everything present on
+the runner. Broadly, that set covers:
+
+- Build configuration set through the action's own inputs (`PROJECT_PATH`, `BUILD_TARGET`,
+  `BUILD_METHOD`, `CUSTOM_PARAMETERS`, `VERSION`, and similar)
+- Unity credentials (`UNITY_LICENSE`, `UNITY_EMAIL`, `UNITY_PASSWORD`, `UNITY_SERIAL`,
+  `UNITY_LICENSING_SERVER`)
+- Android signing and export variables (`ANDROID_KEYSTORE_*`, `ANDROID_EXPORT_TYPE`, and similar)
+- A subset of the standard `GITHUB_*` and `RUNNER_*` variables
+
+Anything outside that set is dropped at the container boundary. This is why an arbitrary variable
+set in `env:` is not visible to Unity.
+
+#### Solution
+
+Pass the value as a Unity editor command line argument via
+[`customParameters`](/docs/github/builder#customparameters) instead, and read it in an editor script
+with `Environment.GetCommandLineArgs()`:
+
+```yaml
+- uses: game-ci/unity-builder@v6
+  with:
+    customParameters: -myCustomFlag someValue
+```
+
+This reaches Unity reliably regardless of whether the build runs in a container.
+
+:::note
+
+This applies to Docker-based builds. When GameCI runs Unity directly on the host (rather than in a
+container), the process does inherit the surrounding environment — so behaviour can differ between
+the two, which is another reason to prefer `customParameters`.
+
+:::
+
 ### Failed to find a suitable OpenCL device for the GPU Lightmapper
 
 #### Error

--- a/docs/09-troubleshooting/common-issues.mdx
+++ b/docs/09-troubleshooting/common-issues.mdx
@@ -402,32 +402,35 @@ Worker counts are the most effective dial for peak memory. Which mechanism you u
 Unity exposes the particular setting — there are three, and not every setting is reachable by all
 of them:
 
-| Setting                                           | How Unity exposes it | How to set it in CI                                                 |
-| ------------------------------------------------- | -------------------- | ------------------------------------------------------------------- |
-| IL2CPP compiler args (`IL2CPP_ADDITIONAL_ARGS`)   | Environment variable | [`dockerEnv`](/docs/github/builder#dockerenv)                       |
-| Job worker threads (`-job-worker-count`)          | Editor command line  | [`customParameters`](/docs/github/builder#customparameters)         |
-| GC helper threads (`-gc-helper-count`)            | Editor command line  | [`customParameters`](/docs/github/builder#customparameters)         |
-| Asset import workers (`desiredImportWorkerCount`) | Editor API only      | Editor script via [`buildMethod`](/docs/github/builder#buildmethod) |
-| IL2CPP code generation, Burst settings            | Editor API only      | Editor script via [`buildMethod`](/docs/github/builder#buildmethod) |
+| Setting                                           | How Unity exposes it | How to set it in CI                                             |
+| ------------------------------------------------- | -------------------- | --------------------------------------------------------------- |
+| IL2CPP compiler args (`IL2CPP_ADDITIONAL_ARGS`)   | Environment variable | [`dockerEnv`](/docs/github/builder#dockerenv)                   |
+| Job worker threads (`-job-worker-count`)          | Editor command line  | [`customParameters`](/docs/github/builder#customparameters)     |
+| GC helper threads (`-gc-helper-count`)            | Editor command line  | [`customParameters`](/docs/github/builder#customparameters)     |
+| Asset import workers (`desiredImportWorkerCount`) | Editor API only      | [`unitySettings`](#setting-any-unity-editor-or-project-setting) |
+| IL2CPP code generation, Burst settings            | Editor API only      | [`unitySettings`](#setting-any-unity-editor-or-project-setting) |
 
-The first two rows need no editor script at all:
+None of these require you to write an editor script:
 
 ```yaml
 - uses: game-ci/unity-builder@v6
   env:
     GAME_CI_DOCKER_ENV: |
       IL2CPP_ADDITIONAL_ARGS=--maxcpucount=2
+    GAME_CI_UNITY_SETTINGS: |
+      EditorUserSettings.desiredImportWorkerCount = 2
   with:
     customParameters: -job-worker-count 2
 ```
 
-Asset import workers are the exception worth knowing about: Unity exposes **no command line
-argument and no environment variable** for them, only the
+Asset import workers are the case worth understanding: Unity exposes **no command line argument and
+no environment variable** for them, only the
 [`EditorUserSettings.desiredImportWorkerCount`](https://docs.unity3d.com/6000.0/Documentation/ScriptReference/EditorUserSettings-desiredImportWorkerCount.html)
-scripting API. Setting those requires an editor script — that is a Unity constraint, not a GameCI
-one.
+scripting API. `unitySettings` applies that API for you — see
+[setting any Unity Editor or Project setting](#setting-any-unity-editor-or-project-setting).
 
-The pattern for the editor-script cases is to inject a worker count through
+If you would rather own the build method yourself, the manual pattern is to inject a worker count
+through
 [`customParameters`](/docs/github/builder#customparameters), then read it in a build method pointed
 at by [`buildMethod`](/docs/github/builder#buildmethod). This keeps the setting CI-only, so your
 committed Project Settings — and everyone's local builds — stay unchanged.
@@ -576,6 +579,70 @@ cannot set them.
 Reserved names are rejected: `dockerEnv` cannot overwrite the variables GameCI sets itself
 (`UNITY_LICENSE`, `PROJECT_PATH`, `BUILD_TARGET`, and similar). You will get a warning naming the
 collision rather than a silently broken build.
+
+:::
+
+### Setting any Unity Editor or Project setting
+
+Some Unity settings exist only as an Editor scripting API — no command line argument, no
+environment variable. Asset import worker counts are the common example. `unitySettings` applies
+those APIs for you, so you do not have to write and maintain a build method just to change a
+setting:
+
+```yaml
+- uses: game-ci/unity-builder@v6
+  env:
+    GAME_CI_UNITY_SETTINGS: |
+      EditorUserSettings.desiredImportWorkerCount = 4
+      EditorUserSettings.standbyImportWorkerCount = 2
+      EditorSettings.refreshImportMode = OutOfProcessPerQueue
+      PlayerSettings.SetIl2CppCodeGeneration(Standalone, OptimizeSize)
+      PlayerSettings.SetAdditionalIl2CppArgs("--maxcpucount=2")
+```
+
+Each line is one directive, in one of two forms:
+
+- **Assignment** — `Type.Member = value`, for properties and fields
+- **Invocation** — `Type.Method(argument, ...)`, for setter methods
+
+Directives are applied by reflection against Unity's own editor assemblies, so **any static
+settings API Unity exposes is reachable** — including ones added in Unity versions released after
+this feature. There is no fixed list of supported settings to check against.
+
+A few conveniences: enum values accept either a bare member (`OptimizeSize`) or a qualified one
+(`Il2CppCodeGeneration.OptimizeSize`); struct presets such as `NamedBuildTarget.Standalone` resolve
+the same way; string arguments take double quotes; and bare type names prefer Unity's own types, so
+`PlayerSettings` means Unity's even if your project defines a class with that name. Blank lines and
+lines starting with `#` or `//` are ignored, so you can annotate the block.
+
+#### Settings are applied CI-only
+
+These are applied at build time, in the CI checkout. Your committed Project Settings are not
+modified, so local development is unaffected — which is usually the point: CI wants fewer import
+workers and smaller code generation than a developer machine does.
+
+#### When a directive does not apply
+
+An unrecognised directive produces a warning and the build continues. This is deliberate: a setting
+that exists in one Unity version but not another should not break an otherwise valid build, which
+matters if you build a matrix of Unity versions.
+
+If you would rather know immediately, set `unitySettingsStrict`:
+
+```yaml
+- uses: game-ci/unity-builder@v6
+  env:
+    GAME_CI_UNITY_SETTINGS_STRICT: 'true'
+    GAME_CI_UNITY_SETTINGS: |
+      EditorUserSettings.desiredImportWorkerCount = 4
+```
+
+Every directive is logged as it is applied, so the build log shows exactly what was set.
+
+:::note
+
+The applier is only added to your project when you actually provide a spec. If `unitySettings` is
+unset, nothing is copied in and the build is byte-for-byte what it was before.
 
 :::
 

--- a/docs/09-troubleshooting/common-issues.mdx
+++ b/docs/09-troubleshooting/common-issues.mdx
@@ -512,9 +512,26 @@ set in `env:` is not visible to Unity.
 
 #### Solution
 
-Pass the value as a Unity editor command line argument via
-[`customParameters`](/docs/github/builder#customparameters) instead, and read it in an editor script
-with `Environment.GetCommandLineArgs()`:
+Forward the variable explicitly with `dockerEnv`. Each entry is a `NAME=value` pair, and the
+variables are set inside the container where Unity can read them normally:
+
+```yaml
+- uses: game-ci/unity-builder@v6
+  env:
+    GAME_CI_DOCKER_ENV: |
+      IL2CPP_ADDITIONAL_ARGS=--maxcpucount=2
+      MY_CUSTOM_FLAG=someValue
+```
+
+Read them in an editor script the usual way:
+
+```csharp
+var args = Environment.GetEnvironmentVariable("IL2CPP_ADDITIONAL_ARGS");
+```
+
+Alternatively, pass the value as a Unity editor command line argument via
+[`customParameters`](/docs/github/builder#customparameters) and read it with
+`Environment.GetCommandLineArgs()`:
 
 ```yaml
 - uses: game-ci/unity-builder@v6
@@ -522,13 +539,54 @@ with `Environment.GetCommandLineArgs()`:
     customParameters: -myCustomFlag someValue
 ```
 
-This reaches Unity reliably regardless of whether the build runs in a container.
+Use `customParameters` when Unity should receive a command line argument, and `dockerEnv` when
+something inside the build genuinely needs an environment variable — Unity's own toolchain
+variables like `IL2CPP_ADDITIONAL_ARGS` are read from the environment, so `customParameters`
+cannot set them.
 
 :::note
 
-This applies to Docker-based builds. When GameCI runs Unity directly on the host (rather than in a
-container), the process does inherit the surrounding environment — so behaviour can differ between
-the two, which is another reason to prefer `customParameters`.
+Reserved names are rejected: `dockerEnv` cannot overwrite the variables GameCI sets itself
+(`UNITY_LICENSE`, `PROJECT_PATH`, `BUILD_TARGET`, and similar). You will get a warning naming the
+collision rather than a silently broken build.
+
+:::
+
+### Setting any option with an environment variable
+
+Every GameCI CLI option can also be set with an environment variable, by upper-snake-casing the
+option name and prefixing it with `GAME_CI_`. These two are equivalent:
+
+```bash
+game-ci build --dockerMemoryLimit 14g
+```
+
+```bash
+GAME_CI_DOCKER_MEMORY_LIMIT=14g game-ci build
+```
+
+This matters most in workflows. The actions are thin wrappers that run the CLI as a normal child
+process, so it inherits the workflow environment — which means an `env:` block can reach **any**
+CLI option, including ones the action has no matching input for:
+
+```yaml
+- uses: game-ci/unity-builder@v6
+  env:
+    GAME_CI_DOCKER_MEMORY_LIMIT: 14g
+    GAME_CI_DOCKER_SHM_SIZE: 2g
+    GAME_CI_DOCKER_ENV: |
+      IL2CPP_ADDITIONAL_ARGS=--maxcpucount=2
+```
+
+Precedence is **explicit input wins over environment variable, which wins over the default**. So an
+action input you have already set is never silently overridden by the environment — `GAME_CI_*`
+only fills in what you left unset.
+
+:::caution
+
+`GAME_CI_` is a reserved prefix. A `GAME_CI_` variable that does not match a real option fails the
+build with `Unknown argument`, rather than being ignored — a typo tells you instead of quietly
+doing nothing. Do not use the prefix for your own unrelated variables.
 
 :::
 


### PR DESCRIPTION
## Summary

Two undocumented behaviours that a user hit live in Discord and lost real time to, plus one missing reference entry.

### 1. Build runs out of memory (new troubleshooting section)

GameCI caps the container's memory at a percentage of host memory — 95% on Linux, **80% on Windows**, 75% elsewhere (`defaultDockerMemoryLimit()` in the CLI). On a standard 16 GB GitHub-hosted Windows runner that means the build gets ~12.8 GB with ~3 GB left unused, and nothing anywhere told you `dockerMemoryLimit` was the knob to reclaim it.

The section also covers the part that actually dominates peak memory — parallelism — and calls out that this hits DOTS/ECS projects disproportionately, since Burst AOT rather than IL2CPP is often the real consumer there. Includes the pattern for applying CI-only settings without changing committed Project Settings (editor script + `customParameters` + `buildMethod`).

### 2. Environment variables don't reach the container (new troubleshooting section)

The container inherits a **fixed allowlist**, not the workflow environment. So setting something like `IL2CPP_ADDITIONAL_ARGS` in `env:` is silently dropped at the container boundary — it looks like it should work, and there's no error to tell you otherwise. Documents what is forwarded, why, and that `customParameters` is the reliable route.

### 3. `dockerShmSize` reference entry (was missing entirely)

It had no entry in the builder reference at all, despite being the documented remedy for `Insufficient shared memory available` on Unity 6.6+.

## Test plan

- [x] `yarn oxfmt --check` passes on both changed files (the repo-wide check reports pre-existing issues across 389 files, untouched here)
- [x] All cross-references verified to resolve against real headings: `#dockermemorylimit`, `#customparameters`, `#buildmethod`
- [x] Facts verified against the CLI source rather than assumed — the memory multipliers, the forwarded-variable list, and the `1025m` shm default all read from `game-ci/cli` directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added guidance for configuring Docker shared memory size and forwarding environment variables.
  - Documented `dockerEnv`, `unitySettings`, and `unitySettingsStrict`, including supported syntax and strict failure behavior.
  - Added troubleshooting guidance for Unity build out-of-memory failures, runner sizing, worker parallelism, and IL2CPP/Burst settings.
  - Clarified environment-variable configuration for CLI options and reserved variable collision warnings.
  - Updated guidance for Unity settings and experimental compiler-flag configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->